### PR TITLE
(TK-170) Inital setup of trapperkeeper status service project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: clojure
+lein: lein2
+jdk:
+- oraclejdk7
+- openjdk7
+script: ./ext/travisci/test.sh
+notifications:
+  email: false
+  hipchat:
+    rooms:
+      secure: CfGS3yYsocLruSP0lRr9HFwzdZ1HFw4rFEVdJkP/i0i8aIPY3XB3vTQNxw/lIBVRDwWHaUfA+xnyK3itCxt0M0UtPDp1BkU6abLr8Apjet/nJJ2icBvQfnpx1hb6xBpoE69vpRiIVewoU69UPFjXdZd2D1BWX58tNbdV9CA8Ezw=
+    template:
+    - ! '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}'
+    - ! 'Change view: %{compare_url}'
+    - ! 'Build details: %{build_url}'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# trapperkeeper-status
-Trapperkeeper Status Service
+# Trapperkeeper Status Service
+
+A trapperkeeper service for getting the status of other trapperkeeper
+services.
+
+## License
+
+Copyright © 2015 Puppet Labs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Trapperkeeper Status Service
 
+[![Build Status](https://travis-ci.org/puppetlabs/trapperkeeper-status.svg)](https://travis-ci.org/puppetlabs/trapperkeeper-status)
+
 A trapperkeeper service for getting the status of other trapperkeeper
 services.
 

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,0 +1,3 @@
+# Introduction to trapperkeeper-status
+
+TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+lein2 test

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,9 @@
+(defproject puppetlabs/trapperkeeper-status "0.1.0-SNAPSHOT"
+  :description "A trapperkeeper service for getting the status of other trapperkeeper services."
+  :url "https://github.com/puppetlabs/trapperkeeper-status"
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
+
+  :pedantic? :abort
+
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,15 @@
 
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+
+  :lein-release {:scm         :git
+                 :deploy-via  :lein-deploy}
+
+  :deploy-repositories [["releases" {:url "https://clojars.org/repo"
+                                     :username :env/clojars_jenkins_username
+                                     :password :env/clojars_jenkins_password
+                                     :sign-releases false}]]
+
+  :plugins [[lein-release "1.0.5"]]
+  )

--- a/src/puppetlabs/trapperkeeper_status.clj
+++ b/src/puppetlabs/trapperkeeper_status.clj
@@ -1,0 +1,6 @@
+(ns puppetlabs.trapperkeeper-status)
+
+(defn foo
+  "I don't do a whole lot."
+  [x]
+  (str x "Hello, World!"))

--- a/test/puppetlabs/trapperkeeper_status_test.clj
+++ b/test/puppetlabs/trapperkeeper_status_test.clj
@@ -1,0 +1,7 @@
+(ns puppetlabs.trapperkeeper-status-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.trapperkeeper-status :refer :all]))
+
+(deftest a-test
+  (testing "I am a test"
+    (is (= "Hello, World!" (foo "")))))


### PR DESCRIPTION
Add skeleton derived from `lein new default puppetlabs/trapperkeeper-status` (so that we have a test to run) and enable travis.
