### PR TITLE
(TK-172) Add endpoint to query status for a single service

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -70,12 +70,12 @@
           {:status 200
            :body statuses}))
        (compojure/GET "/services/:service-name" [service-name]
-         (if-let [status-info (get (deref status-fns-atom) service-name)]
-           (let [status (call-latest-status-fn-for-service status-info)]
+         (if-let [service-info (get (deref status-fns-atom) service-name)]
+           (let [status (call-latest-status-fn-for-service service-info)]
              {:status 200
               :body (assoc status :service-name service-name)})
            {:status 404
-            :body {:error {:type ::service-not-found
+            :body {:error {:type :service-not-found
                            :message (str "No status information found for service "
                                          service-name)}}})))))
 

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -68,7 +68,15 @@
       (compojure/GET "/services" []
         (let [statuses (call-status-fns status-fns-atom)]
           {:status 200
-           :body {"services" statuses}})))))
+           :body {"services" statuses}}))
+       (compojure/GET "/services/:service-name" [service-name]
+         (if-let [status-info (get (deref status-fns-atom) service-name)]
+           {:status 200
+            :body (call-latest-status-fn-for-service status-info)}
+           {:status 404
+            :body {:error {:type ::service-not-found
+                           :message (str "No status information found for service "
+                                         service-name)}}})))))
 
 (defn build-handler [status-fns-atom]
   (-> (build-routes status-fns-atom)

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -71,8 +71,9 @@
            :body {"services" statuses}}))
        (compojure/GET "/services/:service-name" [service-name]
          (if-let [status-info (get (deref status-fns-atom) service-name)]
-           {:status 200
-            :body (call-latest-status-fn-for-service status-info)}
+           (let [status (call-latest-status-fn-for-service status-info)]
+             {:status 200
+              :body (assoc status :service-name service-name)})
            {:status 404
             :body {:error {:type ::service-not-found
                            :message (str "No status information found for service "

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -68,7 +68,7 @@
       (compojure/GET "/services" []
         (let [statuses (call-status-fns status-fns-atom)]
           {:status 200
-           :body {"services" statuses}}))
+           :body statuses}))
        (compojure/GET "/services/:service-name" [service-name]
          (if-let [status-info (get (deref status-fns-atom) service-name)]
            (let [status (call-latest-status-fn-for-service status-info)]

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -44,7 +44,7 @@
               "foo" {"service-version" "1.1.0"
                      "service-status-version" 2
                      "status" "foo status 2"}}
-             (get body "services"))))))
+             body)))))
 
 (deftest single-service-status-endpoint-test
   (with-app-with-config

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -24,7 +24,7 @@
     (register-status "bar" "0.1.0" 1 (fn [] "bar status 1"))
     context))
 
-(deftest status-endpoint-test
+(deftest rollup-status-endpoint-test
   (with-app-with-config
     app
     [jetty9-service/jetty9-service
@@ -45,3 +45,27 @@
                      "service-status-version" 2
                      "status" "foo status 2"}}
              (get body "services"))))))
+
+(deftest single-service-status-endpoint-test
+  (with-app-with-config
+    app
+    [jetty9-service/jetty9-service
+     webrouting-service/webrouting-service
+     status-service
+     foo-service]
+    {:webserver {:port 8180
+                 :host "0.0.0.0"}
+     :web-router-service {:puppetlabs.trapperkeeper.services.status.status-service/status-service "/status"}}
+    (testing "returns service information for service that has registered a callback"
+      (let [req (http-client/get "http://localhost:8180/status/v1/services/foo")]
+        (is (= 200 (:status req)))
+        (is (= {"service-version" "1.1.0"
+                "service-status-version" 2
+                "status" "foo status 2"}
+               (json/parse-string (slurp (:body req)))))))
+    (testing "returns a 404 for service not registered with the status service"
+      (let [req (http-client/get "http://localhost:8180/status/v1/services/notfound")]
+        (is (= 404 (:status req)))
+        (is (= {"error" {"type" "puppetlabs.trapperkeeper.services.status.status-core/service-not-found"
+                         "message" "No status information found for service notfound"}}
+               (json/parse-string (slurp (:body req)))))))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -67,6 +67,6 @@
     (testing "returns a 404 for service not registered with the status service"
       (let [req (http-client/get "http://localhost:8180/status/v1/services/notfound")]
         (is (= 404 (:status req)))
-        (is (= {"error" {"type" "puppetlabs.trapperkeeper.services.status.status-core/service-not-found"
+        (is (= {"error" {"type" "service-not-found"
                          "message" "No status information found for service notfound"}}
                (json/parse-string (slurp (:body req)))))))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -61,7 +61,8 @@
         (is (= 200 (:status req)))
         (is (= {"service-version" "1.1.0"
                 "service-status-version" 2
-                "status" "foo status 2"}
+                "status" "foo status 2"
+                "service-name" "foo"}
                (json/parse-string (slurp (:body req)))))))
     (testing "returns a 404 for service not registered with the status service"
       (let [req (http-client/get "http://localhost:8180/status/v1/services/notfound")]


### PR DESCRIPTION
Add the ability to query for a single service's status at
/status/v1/services/<service name>. If the service has multiple status
callback functions registered, the endpoint returns the result of calling the
latest (same as for the rollup endpoint). If the service is nonexistent/hasn't
registered itself with the status service, the endpoint returns a 404.
