### PR TITLE
(TK-174) Query based on status level

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,7 @@
                  [compojure "1.1.8" :exclusions [commons-io org.clojure/tools.macro]]
                  [prismatic/schema "0.4.0"]
                  [ring/ring-json "0.3.1" :exclusions [commons-io]]
+                 [slingshot "0.12.2"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]]
 

--- a/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
@@ -1,0 +1,65 @@
+;; TODO: Much of this code is copied from other projects. It should
+;; probably be moved into a shared library or some such.
+(ns puppetlabs.trapperkeeper.services.status.ringutils
+  (:require [clojure.tools.logging :as log]
+            [slingshot.slingshot :refer [try+]]
+            [puppetlabs.kitchensink.core :as ks]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(defn wrap-request-logging
+  "A ring middleware that logs the request."
+  [handler]
+  (fn [{:keys [request-method uri] :as req}]
+    (log/debug "Processing" request-method uri)
+    (log/trace "---------------------------------------------------")
+    (log/trace (ks/pprint-to-string (dissoc req :ssl-client-cert)))
+    (log/trace "---------------------------------------------------")
+    (handler req)))
+
+(defn wrap-response-logging
+  "A ring middleware that logs the response."
+  [handler]
+  (fn [req]
+    (let [resp (handler req)]
+      (log/trace "Computed response:" resp)
+      resp)))
+
+(defn wrap-request-data-errors
+  "A rignt middleware that catches slingshot errors of :type
+  :request-dava-invalid and returns a 400."
+  [handler]
+  (fn [request]
+    (try+ (handler request)
+          (catch [:type :request-data-invalid] e
+            {:status 400
+             :body {:error e}}))))
+
+(defn wrap-schema-errors
+  "A ring middleware that catches schema errors and returns a 500
+  response with the details"
+  [handler]
+  (fn [request]
+    (try (handler request)
+         (catch clojure.lang.ExceptionInfo e
+           (let [message (.getMessage e)]
+             (if (re-find #"does not match schema" message)
+               {:status 500
+                :body {:error {:type :application-error
+                               :message (str "Something unexpected happened: "
+                                             (:error (.getData e)))}}}
+               ;; re-throw exceptions that aren't schema errors
+               (throw e)))))))
+
+(defn wrap-errors
+  "A ring middleware that catches all otherwise uncaught errors and
+  returns a 500 response with the error message"
+  [handler]
+  (fn [request]
+    (try (handler request)
+         (catch Exception e
+           (log/error e "Error on server")
+           {:status 500
+            :body {:error {:type :application-error
+                           :message (str "Error on server: " e)}}}))))

--- a/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
@@ -9,7 +9,7 @@
 ;;; Public
 
 (defn wrap-request-data-errors
-  "A rignt middleware that catches slingshot errors of :type
+  "A ring middleware that catches slingshot errors of :type
   :request-dava-invalid and returns a 400."
   [handler]
   (fn [request]

--- a/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
@@ -8,24 +8,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
-(defn wrap-request-logging
-  "A ring middleware that logs the request."
-  [handler]
-  (fn [{:keys [request-method uri] :as req}]
-    (log/debug "Processing" request-method uri)
-    (log/trace "---------------------------------------------------")
-    (log/trace (ks/pprint-to-string (dissoc req :ssl-client-cert)))
-    (log/trace "---------------------------------------------------")
-    (handler req)))
-
-(defn wrap-response-logging
-  "A ring middleware that logs the response."
-  [handler]
-  (fn [req]
-    (let [resp (handler req)]
-      (log/trace "Computed response:" resp)
-      resp)))
-
 (defn wrap-request-data-errors
   "A rignt middleware that catches slingshot errors of :type
   :request-dava-invalid and returns a 400."

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -45,23 +45,24 @@
   (let [status-map (service-status-map svc-version status-version status-fn)]
     (swap! status-fns-atom update-in [svc-name] conj status-map)))
 
-(schema/defn call-latest-status-fn-for-service :- ServiceStatus
+(schema/defn ^:always-validate call-latest-status-fn-for-service :- ServiceStatus
   "Given a list of maps containing service information and a status function,
   find the latest version, and return a map with the service's version, the
   version of the service's status, and the results of calling this status
   function."
   [service :- [ServiceInfo]
-   level]
+   level :- ServiceStatusDetailLevel]
   (let [latest-status (last (sort-by :service-status-version service))]
     (assoc (select-keys latest-status [:service-version :service-status-version])
            :status ((:status-fn latest-status) level))))
 
-(schema/defn call-status-fns :- ServicesStatus
+(schema/defn ^:always-validate call-status-fns :- ServicesStatus
   "Call the latest status function for each service in the service context,
   and return a map of service to service status."
-  [status-fns-atom level]
+  [status-fns :- ServicesInfo
+   level :- ServiceStatusDetailLevel]
   (into {} (pmap (fn [[k v]] {k (call-latest-status-fn-for-service v level)})
-                 (deref status-fns-atom))))
+                 status-fns)))
 
 (defn get-status-detail-level
   "Given a params map from a request, get out the status level and check
@@ -86,7 +87,7 @@
       (compojure/context "/v1" []
         (compojure/GET "/services" [:as {params :query-params}]
           (let [level (get-status-detail-level params)
-                statuses (call-status-fns status-fns-atom level)]
+                statuses (call-status-fns (deref status-fns-atom) level)]
             {:status 200
              :body statuses}))
          (compojure/GET "/services/:service-name" [service-name :as {params :query-params}]
@@ -103,5 +104,6 @@
 (defn build-handler [status-fns-atom]
   (-> (build-routes status-fns-atom)
       ringutils/wrap-request-data-errors
+      ringutils/wrap-schema-errors
       ringutils/wrap-errors
       ring-json/wrap-json-response))

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -69,7 +69,7 @@
   whether it is valid. If not, throw an error. If no status level was in the
   params, then default to 'info'."
   [params]
-  (if-let [level (keyword (params "level"))]
+  (if-let [level (keyword (params :level))]
     (if-not (schema/check ServiceStatusDetailLevel level)
       level
       (throw+  {:type :request-data-invalid
@@ -82,15 +82,15 @@
 
 (defn build-routes
   [status-fns-atom]
-  (handler/site
+  (handler/api
     (compojure/routes
       (compojure/context "/v1" []
-        (compojure/GET "/services" [:as {params :query-params}]
+        (compojure/GET "/services" [:as {params :params}]
           (let [level (get-status-detail-level params)
                 statuses (call-status-fns (deref status-fns-atom) level)]
             {:status 200
              :body statuses}))
-         (compojure/GET "/services/:service-name" [service-name :as {params :query-params}]
+         (compojure/GET "/services/:service-name" [service-name :as {params :params}]
            (if-let [service-info (get (deref status-fns-atom) service-name)]
              (let [level (get-status-detail-level params)
                    status (call-latest-status-fn-for-service service-info level)]

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -48,9 +48,9 @@
     [foo-service
      bar-service]
     (testing "returns latest status for all services"
-      (let [req (http-client/get "http://localhost:8180/status/v1/services")
-            body (json/parse-string (slurp (:body req)))]
-        (is (= 200 (:status req)))
+      (let [resp (http-client/get "http://localhost:8180/status/v1/services")
+            body (json/parse-string (slurp (:body resp)))]
+        (is (= 200 (:status resp)))
         (is (= {"bar" {"service-version" "0.1.0"
                        "service-status-version" 1
                        "status" "bar status 1 :info"}
@@ -59,9 +59,9 @@
                        "status" "foo status 2 :info"}}
                body))))
     (testing "uses status level from query param"
-      (let [req (http-client/get "http://localhost:8180/status/v1/services?level=debug")
-            body (json/parse-string (slurp (:body req)))]
-        (is (= 200 (:status req)))
+      (let [resp (http-client/get "http://localhost:8180/status/v1/services?level=debug")
+            body (json/parse-string (slurp (:body resp)))]
+        (is (= 200 (:status resp)))
         (is (= {"bar" {"service-version" "0.1.0"
                        "service-status-version" 1
                        "status" "bar status 1 :debug"}
@@ -75,33 +75,33 @@
     app
     [foo-service]
     (testing "returns service information for service that has registered a callback"
-      (let [req (http-client/get "http://localhost:8180/status/v1/services/foo")]
-        (is (= 200 (:status req)))
+      (let [resp (http-client/get "http://localhost:8180/status/v1/services/foo")]
+        (is (= 200 (:status resp)))
         (is (= {"service-version" "1.1.0"
                 "service-status-version" 2
                 "status" "foo status 2 :info"
                 "service-name" "foo"}
-               (json/parse-string (slurp (:body req)))))))
+               (json/parse-string (slurp (:body resp)))))))
     (testing "uses status level query param"
-      (let [req (http-client/get "http://localhost:8180/status/v1/services/foo?level=critical")]
-        (is (= 200 (:status req)))
+      (let [resp (http-client/get "http://localhost:8180/status/v1/services/foo?level=critical")]
+        (is (= 200 (:status resp)))
         (is (= {"service-version" "1.1.0"
                 "service-status-version" 2
                 "status" "foo status 2 :critical"
                 "service-name" "foo"}
-               (json/parse-string (slurp (:body req)))))))
+               (json/parse-string (slurp (:body resp)))))))
     (testing "returns a 404 for service not registered with the status service"
-      (let [req (http-client/get "http://localhost:8180/status/v1/services/notfound")]
-        (is (= 404 (:status req)))
+      (let [resp (http-client/get "http://localhost:8180/status/v1/services/notfound")]
+        (is (= 404 (:status resp)))
         (is (= {"error" {"type" "service-not-found"
                          "message" "No status information found for service notfound"}}
-               (json/parse-string (slurp (:body req)))))))))
+               (json/parse-string (slurp (:body resp)))))))))
 
 (deftest error-handling-test
   (with-status-service app []
     (testing "returns a 400 when an invalid level is queried for"
-      (let [req (http-client/get "http://localhost:8180/status/v1/services?level=bar")]
-        (is (= 400 (:status req)))
+      (let [resp (http-client/get "http://localhost:8180/status/v1/services?level=bar")]
+        (is (= 400 (:status resp)))
         (is (= {"error" {"type" "request-data-invalid"
                          "message" "Invalid level: :bar"}}
-               (json/parse-string (slurp (:body req)))))))))
+               (json/parse-string (slurp (:body resp)))))))))


### PR DESCRIPTION
Add support for a `level` query param. When this query param is used, the
status function for the services are called with that level. If no level is
specified, defaults to `info`.

Also adds ringutils to help handle HTTP errors.

~~This is based off of #3 and will likely need to be rebased after that is in.~~ This PR has been rebased and should now be able to be merged.
