### PR TITLE
(TK-173) Support querying based on status-version

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
@@ -14,7 +14,8 @@
   [handler]
   (fn [request]
     (try+ (handler request)
-          (catch [:type :request-data-invalid] e
+          (catch #(or (= :request-data-invalid (:type %))
+                      (= :service-status-version-not-found (:type %))) e
             {:status 400
              :body {:error e}}))))
 

--- a/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
@@ -14,8 +14,8 @@
   [handler]
   (fn [request]
     (try+ (handler request)
-          (catch #(or (= :request-data-invalid (:type %))
-                      (= :service-status-version-not-found (:type %))) e
+          (catch #(contains? #{:request-data-invalid :service-status-version-not-found}
+                             (:type %)) e
             {:status 400
              :body {:error e}}))))
 

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -98,12 +98,11 @@
    check whether it is valid. If not, throw an error."
   [params]
   (when-let [level (params :service-status-version)]
-    (try
-      (Integer. level)
-      (catch NumberFormatException e
-        (throw+ {:type :request-data-invalid
-                 :message (str "Invalid service-status-version. Should be an "
-                               "integer but was " level)})))))
+    (if-let [parsed-level (ks/parse-int level)]
+      parsed-level
+      (throw+ {:type    :request-data-invalid
+               :message (str "Invalid service-status-version. Should be an "
+                             "integer but was " level)}))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -45,23 +45,40 @@
   (let [status-map (service-status-map svc-version status-version status-fn)]
     (swap! status-fns-atom update-in [svc-name] conj status-map)))
 
-(schema/defn ^:always-validate call-latest-status-fn-for-service :- ServiceStatus
+(schema/defn ^:always-validate call-status-fn-for-service :- ServiceStatus
   "Given a list of maps containing service information and a status function,
-  find the latest version, and return a map with the service's version, the
+  find the specified version, and return a map with the service's version, the
   version of the service's status, and the results of calling this status
-  function."
-  [service :- [ServiceInfo]
-   level :- ServiceStatusDetailLevel]
-  (let [latest-status (last (sort-by :service-status-version service))]
-    (assoc (select-keys latest-status [:service-version :service-status-version])
-           :status ((:status-fn latest-status) level))))
+  function. If no version for the status function is specified, the most recent
+  version will be used."
+  ([service-name :- schema/Str
+    service :- [ServiceInfo]
+    level :- ServiceStatusDetailLevel]
+    (call-status-fn-for-service service-name service level nil))
+  ([service-name :- schema/Str
+    service :- [ServiceInfo]
+    level :- ServiceStatusDetailLevel
+    service-status-version :- (schema/maybe schema/Int)]
+    (let [status (if (nil? service-status-version)
+                   (last (sort-by :service-status-version service))
+                   (first (filter #(= (:service-status-version %)
+                                      service-status-version)
+                                  service)))]
+      (when (nil? status)
+        (throw+ {:type    :service-status-version-not-found
+                 :message (str "No status function with version "
+                               service-status-version
+                               " found for service "
+                               service-name)}))
+      (assoc (select-keys status [:service-version :service-status-version])
+        :status ((:status-fn status) level)))))
 
 (schema/defn ^:always-validate call-status-fns :- ServicesStatus
   "Call the latest status function for each service in the service context,
   and return a map of service to service status."
   [status-fns :- ServicesInfo
    level :- ServiceStatusDetailLevel]
-  (into {} (pmap (fn [[k v]] {k (call-latest-status-fn-for-service v level)})
+  (into {} (pmap (fn [[k v]] {k (call-status-fn-for-service k v level)})
                  status-fns)))
 
 (defn get-status-detail-level
@@ -76,6 +93,18 @@
                 :message (str "Invalid level: " level)}))
     :info))
 
+(defn get-service-status-version
+  "Given a params map from a request, get out the service status version and
+   check whether it is valid. If not, throw an error."
+  [params]
+  (when-let [level (params :service-status-version)]
+    (try
+      (Integer. level)
+      (catch NumberFormatException e
+        (throw+ {:type :request-data-invalid
+                 :message (str "Invalid service-status-version. Should be an "
+                               "integer but was " level)})))))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Compojure App
@@ -87,13 +116,18 @@
       (compojure/context "/v1" []
         (compojure/GET "/services" [:as {params :params}]
           (let [level (get-status-detail-level params)
-                statuses (call-status-fns (deref status-fns-atom) level)]
+                statuses (call-status-fns (deref status-fns-atom)
+                                          level)]
             {:status 200
              :body statuses}))
          (compojure/GET "/services/:service-name" [service-name :as {params :params}]
            (if-let [service-info (get (deref status-fns-atom) service-name)]
              (let [level (get-status-detail-level params)
-                   status (call-latest-status-fn-for-service service-info level)]
+                   service-status-version (get-service-status-version params)
+                   status (call-status-fn-for-service service-name
+                                                      service-info
+                                                      level
+                                                      service-status-version)]
                {:status 200
                 :body (assoc status :service-name service-name)})
              {:status 404

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -90,6 +90,14 @@
                 "status" "foo status 2 :critical"
                 "service-name" "foo"}
                (json/parse-string (slurp (:body resp)))))))
+    (testing "uses service-status-version query param"
+      (let [resp (http-client/get "http://localhost:8180/status/v1/services/foo?service-status-version=1")]
+        (is (= 200 (:status resp)))
+        (is (= {"service-version" "1.1.0"
+                "service-status-version" 1
+                "status" "foo status 1 :info"
+                "service-name" "foo"}
+               (json/parse-string (slurp (:body resp)))))))
     (testing "returns a 404 for service not registered with the status service"
       (let [resp (http-client/get "http://localhost:8180/status/v1/services/notfound")]
         (is (= 404 (:status resp)))
@@ -98,10 +106,27 @@
                (json/parse-string (slurp (:body resp)))))))))
 
 (deftest error-handling-test
-  (with-status-service app []
+  (with-status-service app
+    [foo-service]
     (testing "returns a 400 when an invalid level is queried for"
       (let [resp (http-client/get "http://localhost:8180/status/v1/services?level=bar")]
         (is (= 400 (:status resp)))
         (is (= {"error" {"type" "request-data-invalid"
                          "message" "Invalid level: :bar"}}
+               (json/parse-string (slurp (:body resp)))))))
+    (testing "returns a 400 when a non-integer status-version is queried for"
+      (let [resp (http-client/get (str "http://localhost:8180/status/v1/"
+                                       "services/foo?service-status-version=abc"))]
+        (is (= 400 (:status resp)))
+        (is (= {"error" {"type"    "request-data-invalid"
+                         "message" (str "Invalid service-status-version. "
+                                        "Should be an integer but was abc")}}
+               (json/parse-string (slurp (:body resp)))))))
+    (testing "returns a 400 when a non-existent status-version is queried for"
+      (let [resp (http-client/get (str "http://localhost:8180/status/v1/"
+                                        "services/foo?service-status-version=3"))]
+        (is (= 400 (:status resp)))
+        (is (= {"error" {"type"    "service-status-version-not-found"
+                         "message" (str "No status function with version 3 "
+                                        "found for service foo")}}
                (json/parse-string (slurp (:body resp)))))))))


### PR DESCRIPTION
Add support for querying based on a specific version of a
service's registered status function using the
service-status-version parameter.
