### PR TITLE
(TK-216) Fix hard-coded url prefix

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -12,15 +12,16 @@
 
 (defservice status-service
   StatusService
-  [[:WebroutingService add-ring-handler]]
+  [[:WebroutingService add-ring-handler get-route]]
 
   (init [this context]
     (assoc context :status-fns (atom {})))
 
   (start [this context]
     (log/info "Registering status service HTTP API at /status")
-    (let [handler (core/build-handler (:status-fns context))]
-      (add-ring-handler this (compojure/context "/status" [] handler)))
+    (let [path (get-route this)
+          handler (core/build-handler (:status-fns context))]
+      (add-ring-handler this (compojure/context path [] handler)))
     context)
 
   (register-status [this service-name service-version status-version status-fn]

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -70,6 +70,18 @@
                        "status" "foo status 2 :debug"}}
                body))))))
 
+(deftest alternate-mount-point-test
+  (testing "can mount status endpoint at alternate location"
+    (with-app-with-config
+      app
+      [jetty9-service/jetty9-service
+       webrouting-service/webrouting-service
+       status-service]
+      (merge status-service-config
+             {:web-router-service {:puppetlabs.trapperkeeper.services.status.status-service/status-service "/alternate-status"}})
+      (let [resp (http-client/get "http://localhost:8180/alternate-status/v1/services")]
+        (is (= 200 (:status resp)))))))
+
 (deftest single-service-status-endpoint-test
   (with-status-service
     app


### PR DESCRIPTION
The status service had a hard-coded path of `/status` that it
was passing to compojure's `context` macro, but was using
the web routing service to find the path where we mounted in
Jetty.  This meant that it was possible to configure the
web routing service to something other than `/status`, but
if you did so, the service would not be accessible.
