### PR TITLE
(maint) Pass status functions to routes, not atom

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -20,7 +20,7 @@
   (start [this context]
     (log/info "Registering status service HTTP API at /status")
     (let [path (get-route this)
-          handler (core/build-handler (:status-fns context))]
+          handler (core/build-handler (deref (:status-fns context)))]
       (add-ring-handler this (compojure/context path [] handler)))
     context)
 


### PR DESCRIPTION
The `status-fns` atom in the status service's context should be updated uring
that service's init. Thus, by the time start is called it should be immutable.
This commit moves the dereferencing of the atom into `start` in the service
namespace, so that the route-related functions in the core namespace only deal
with a map.
