### PR TITLE
(TK-210) Add utility function for getting service version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,8 @@
 
   :pedantic? :abort
 
+  :exclusions [org.clojure/clojure]
+
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.3.1"]
                  [compojure "1.1.8" :exclusions [commons-io org.clojure/tools.macro]]
@@ -16,7 +18,9 @@
                  [ring/ring-json "0.3.1" :exclusions [commons-io]]
                  [slingshot "0.12.2"]
                  [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/trapperkeeper ~tk-version]]
+                 [puppetlabs/trapperkeeper ~tk-version]
+                 [grimradical/clj-semver "0.3.0"]
+                 [trptcolin/versioneer "0.2.0"]]
 
   :lein-release {:scm         :git
                  :deploy-via  :lein-deploy}
@@ -31,5 +35,4 @@
                                   [puppetlabs/trapperkeeper-webserver-jetty9 "1.3.1"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]]}}
 
-  :plugins [[lein-release "1.0.5"]]
-  )
+  :plugins [[lein-release "1.0.5"]])

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -5,7 +5,9 @@
             [ring.middleware.json :as ring-json]
             [slingshot.slingshot :refer [throw+]]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.trapperkeeper.services.status.ringutils :as ringutils]))
+            [puppetlabs.trapperkeeper.services.status.ringutils :as ringutils]
+            [clj-semver.core :as semver]
+            [trptcolin.versioneer.core :as versioneer]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
@@ -30,8 +32,29 @@
 (def ServicesStatus
   {schema/Str ServiceStatus})
 
+(def SemVerVersion
+  (schema/pred semver/valid-format? "semver"))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
+
+(schema/defn ^:always-validate
+  get-service-version :- SemVerVersion
+  [group-id artifact-id]
+  (let [version (versioneer/get-version group-id artifact-id)]
+    (when-not version
+      (throw (IllegalStateException.
+               (format "Unable to find version number for '%s/%s'"
+                       group-id
+                       artifact-id))))
+    (when-not (semver/valid-format? version)
+      (throw (IllegalStateException.
+               (format "Service '%s/%s' has version that does not comply with semver: '%s'"
+                       group-id
+                       artifact-id
+                       version))))
+    version))
+
 
 (schema/defn service-status-map :- ServiceInfo
   [svc-version status-version status-fn]

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -2,9 +2,24 @@
   (:require [clojure.test :refer :all]
             [schema.core :as schema]
             [schema.test :as schema-test]
-            [puppetlabs.trapperkeeper.services.status.status-core :refer :all]))
+            [puppetlabs.trapperkeeper.services.status.status-core :refer :all]
+            [trptcolin.versioneer.core :as versioneer]))
 
 (use-fixtures :once schema-test/validate-schemas)
+
+(deftest get-service-version-test
+  (testing "get-service-version returns a version string that satisfies the schema"
+    ;; This test coverage isn't very thorough, but anything beyond this would
+    ;; really just be testing the underlying libraries that we use to
+    ;; implement it.
+    (is (nil? (schema/check
+                SemVerVersion
+                (get-service-version "puppetlabs" "trapperkeeper-status"))))
+    (is (thrown? IllegalStateException
+                 (get-service-version "fake-group" "artifact-that-does-not-exist")))
+    (with-redefs [versioneer/get-version (constantly "bad-version-string")]
+      (is (thrown? IllegalStateException
+                   (get-service-version "puppetlabs" "trapperkeeper-status"))))))
 
 (deftest update-status-context-test
   (let [status-fns (atom {})]


### PR DESCRIPTION
Because `service-version` is a required field for registering
a callback, and because we don't want to force all of the
consumers of this service to maintain a hard-coded instance
of that value by hand every time they do a new release of their
code, this commit introduces a utility function called
`get-service-version`.  If passed a valid maven group id and
artifact id, it will get the version string for that component.

This is intended to be used by downstream services; they should
call this prior to registering their callback, and then pass in
this value as the `service-version`.
