### PR TITLE
(TK-212) Error when service version already exists

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -42,14 +42,21 @@
 (defn update-status-context
   "Update the :status-fns atom in the service context."
   [status-fns-atom svc-name svc-version status-version status-fn]
-  (when-not (empty? (filter #(= (:service-status-version %)
-                                status-version)
-                            (get (deref status-fns-atom) svc-name)))
-    (throw
-      (IllegalStateException.
-        (str "Service function already exists for service " svc-name
-             " with version " svc-version " and status version "
-             status-version))))
+  (let [callbacks (get (deref status-fns-atom) svc-name)]
+    (when-let [first-callback (first callbacks)]
+      (when (not= (:service-version first-callback) svc-version)
+        (throw
+          (IllegalStateException.
+            (str "Cannot register multiple callbacks for a single service with "
+                 "different service versions.")))))
+    (when-not (empty? (filter #(= (:service-status-version %)
+                                  status-version)
+                              callbacks))
+      (throw
+        (IllegalStateException.
+          (str "Service function already exists for service " svc-name
+               " with version " svc-version " and status version "
+               status-version)))))
   (let [status-map (service-status-map svc-version status-version status-fn)]
     (swap! status-fns-atom update-in [svc-name] conj status-map)))
 

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -42,6 +42,14 @@
 (defn update-status-context
   "Update the :status-fns atom in the service context."
   [status-fns-atom svc-name svc-version status-version status-fn]
+  (when-not (empty? (filter #(= (:service-status-version %)
+                                status-version)
+                            (get (deref status-fns-atom) svc-name)))
+    (throw
+      (IllegalStateException.
+        (str "Service function already exists for service " svc-name
+             " with version " svc-version " and status version "
+             status-version))))
   (let [status-map (service-status-map svc-version status-version status-fn)]
     (swap! status-fns-atom update-in [svc-name] conj status-map)))
 

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -15,4 +15,17 @@
 
       (is (nil? (schema/check ServicesInfo @status-fns)))
       (is (= 2 (count (get @status-fns "foo"))))
-      (is (= 1 (count (get @status-fns "bar")))))))
+      (is (= 1 (count (get @status-fns "bar")))))
+
+    (testing (str "registering a service status callback function with a "
+                  "version that already exists causes an error")
+      (is (thrown? IllegalStateException
+                   (update-status-context status-fns "foo"
+                                          "1.1.0" 2 (fn [] "foo repeat")))))
+
+    (testing (str "registering a service status callback function with a "
+                  "status version that already exists but a different service "
+                  "version causes an error")
+      (is (thrown? IllegalStateException
+                   (update-status-context status-fns "foo"
+                                          "1.2.0" 2 (fn [] "foo repeat")))))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -19,13 +19,16 @@
 
     (testing (str "registering a service status callback function with a "
                   "version that already exists causes an error")
-      (is (thrown? IllegalStateException
-                   (update-status-context status-fns "foo"
-                                          "1.1.0" 2 (fn [] "foo repeat")))))
+      (is (thrown-with-msg? IllegalStateException
+                            #"Service function already exists.*"
+                            (update-status-context status-fns "foo"
+                                                   "1.1.0" 2
+                                                   (fn [] "foo repeat")))))
 
     (testing (str "registering a service status callback function with a "
-                  "status version that already exists but a different service "
-                  "version causes an error")
-      (is (thrown? IllegalStateException
-                   (update-status-context status-fns "foo"
-                                          "1.2.0" 2 (fn [] "foo repeat")))))))
+                  "different service version causes an error")
+      (is (thrown-with-msg? IllegalStateException
+                            #"Cannot register multiple callbacks.*different service version"
+                            (update-status-context status-fns "foo"
+                                                   "1.2.0" 3
+                                                   (fn [] "foo repeat")))))))


### PR DESCRIPTION
Throw an exception when a user tries to register multiple
callbacks for a service at the same service level.
