### PR TITLE
(TK-209) Add :is_running to status service output

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
@@ -31,7 +31,7 @@
                {:status 500
                 :body {:error {:type :application-error
                                :message (str "Something unexpected happened: "
-                                             (:error (.getData e)))}}}
+                                             (select-keys (.getData e) [:error :value :type]))}}}
                ;; re-throw exceptions that aren't schema errors
                (throw e)))))))
 

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -13,8 +13,11 @@
 (def ServiceStatusDetailLevel
   (schema/enum :critical :info :debug))
 
+(def IsRunning
+  (schema/enum :true :false :unknown))
+
 (def StatusCallbackResponse
-  {:is-running schema/Bool
+  {:is-running IsRunning
    :status schema/Any})
 
 (def ServiceInfo
@@ -27,12 +30,14 @@
 (def ServicesInfo
   {schema/Str [ServiceInfo]})
 
-;; this is what gets returned in the HTTP response as json, and thus should
-;; use underscores rather than hyphens
+;; this is what gets returned in the HTTP response as json, and thus uses
+;; underscores rather than hyphens
+;; TODO: merge StatusCallbackResponse with this, rather than duplicating its
+;; two keys, and remove underscores from this schema.
 (def ServiceStatus
   {:service_version schema/Str
    :service_status_version schema/Int
-   :is_running (schema/enum true false :unknown)
+   :is_running IsRunning
    :detail_level ServiceStatusDetailLevel
    :status schema/Any})
 
@@ -82,7 +87,7 @@
                                service-name)}))
       (let [callback-resp ((:status-fn status) level)
             data (:status callback-resp)
-            is-running (if-not (schema/check schema/Bool (:is-running callback-resp))
+            is-running (if-not (schema/check IsRunning (:is-running callback-resp))
                          (:is-running callback-resp)
                          :unknown)]
         {:service_version (:service-version status)

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -31,6 +31,7 @@
   {:service-version schema/Str
    :service-status-version schema/Int
    :is-running (schema/enum true false :unknown)
+   :detail-level ServiceStatusDetailLevel
    :status schema/Any})
 
 (def ServicesStatus
@@ -52,11 +53,12 @@
     (swap! status-fns-atom update-in [svc-name] conj status-map)))
 
 (schema/defn ^:always-validate call-status-fn-for-service :- ServiceStatus
-  "Given a list of maps containing service information and a status function,
-  find the specified version, and return a map with the service's version, the
-  version of the service's status, and the results of calling this status
-  function. If no version for the status function is specified, the most recent
-  version will be used."
+  "Construct a map with the service's version, the version of the service's
+  status, the detail level, and the results of calling the status function
+  corresponding to the status version specified (or the most recent version if
+  not). If the response from the callback function does not include an
+  :is-running key, or returns a value other than true or false, return
+  :unknown for :is-running."
   ([service-name :- schema/Str
     service :- [ServiceInfo]
     level :- ServiceStatusDetailLevel]
@@ -82,7 +84,7 @@
                          (:is-running callback-resp)
                          :unknown)
             versions (select-keys status [:service-version :service-status-version])]
-        (assoc versions :status data :is-running is-running)))))
+        (assoc versions :detail-level level :status data :is-running is-running)))))
 
 (schema/defn ^:always-validate call-status-fns :- ServicesStatus
   "Call the latest status function for each service in the service context,

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -27,11 +27,13 @@
 (def ServicesInfo
   {schema/Str [ServiceInfo]})
 
+;; this is what gets returned in the HTTP response as json, and thus should
+;; use underscores rather than hyphens
 (def ServiceStatus
-  {:service-version schema/Str
-   :service-status-version schema/Int
-   :is-running (schema/enum true false :unknown)
-   :detail-level ServiceStatusDetailLevel
+  {:service_version schema/Str
+   :service_status_version schema/Int
+   :is_running (schema/enum true false :unknown)
+   :detail_level ServiceStatusDetailLevel
    :status schema/Any})
 
 (def ServicesStatus
@@ -82,9 +84,12 @@
             data (:status callback-resp)
             is-running (if-not (schema/check schema/Bool (:is-running callback-resp))
                          (:is-running callback-resp)
-                         :unknown)
-            versions (select-keys status [:service-version :service-status-version])]
-        (assoc versions :detail-level level :status data :is-running is-running)))))
+                         :unknown)]
+        {:service_version (:service-version status)
+         :service_status_version (:service-status-version status)
+         :detail_level level
+         :is_running is-running
+         :status data}))))
 
 (schema/defn ^:always-validate call-status-fns :- ServicesStatus
   "Call the latest status function for each service in the service context,
@@ -114,11 +119,11 @@
   "Given a params map from a request, get out the service status version and
    check whether it is valid. If not, throw an error."
   [params]
-  (when-let [level (params :service-status-version)]
+  (when-let [level (params :service_status_version)]
     (if-let [parsed-level (ks/parse-int level)]
       parsed-level
       (throw+ {:type    :request-data-invalid
-               :message (str "Invalid service-status-version. Should be an "
+               :message (str "Invalid service_status_version. Should be an "
                              "integer but was " level)}))))
 
 
@@ -144,7 +149,7 @@
                                                       level
                                                       service-status-version)]
                {:status 200
-                :body (assoc status :service-name service-name)})
+                :body (assoc status :service_name service-name)})
              {:status 404
               :body {:error {:type :service-not-found
                              :message (str "No status information found for service "

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -33,16 +33,16 @@
   [[:StatusService register-status]]
   (init [this context]
     (register-status "foo" "1.1.0" 1 (fn [level] {:status (str "foo status 1 " level)
-                                                  :is-running true}))
+                                                  :is-running :true}))
     (register-status "foo" "1.1.0" 2 (fn [level] {:status (str "foo status 2 " level)
-                                                  :is-running true}))
+                                                  :is-running :true}))
     context))
 
 (defservice bar-service
   [[:StatusService register-status]]
   (init [this context]
     (register-status "bar" "0.1.0" 1 (fn [level] {:status (str "bar status 1 " level)
-                                                  :is-running false}))
+                                                  :is-running :false}))
     context))
 
 (defservice baz-service
@@ -62,12 +62,12 @@
         (is (= 200 (:status resp)))
         (is (= {"bar" {"service_version" "0.1.0"
                        "service_status_version" 1
-                       "is_running" false
+                       "is_running" "false"
                        "detail_level" "info"
                        "status" "bar status 1 :info"}
                 "foo" {"service_version" "1.1.0"
                        "service_status_version" 2
-                       "is_running" true
+                       "is_running" "true"
                        "detail_level" "info"
                        "status" "foo status 2 :info"}}
                body))))
@@ -77,12 +77,12 @@
         (is (= 200 (:status resp)))
         (is (= {"bar" {"service_version" "0.1.0"
                        "service_status_version" 1
-                       "is_running" false
+                       "is_running" "false"
                        "detail_level" "debug"
                        "status" "bar status 1 :debug"}
                 "foo" {"service_version" "1.1.0"
                        "service_status_version" 2
-                       "is_running" true
+                       "is_running" "true"
                        "detail_level" "debug"
                        "status" "foo status 2 :debug"}}
                body))))))
@@ -109,7 +109,7 @@
         (is (= 200 (:status resp)))
         (is (= {"service_version" "1.1.0"
                 "service_status_version" 2
-                "is_running" true
+                "is_running" "true"
                 "detail_level" "info"
                 "status" "foo status 2 :info"
                 "service_name" "foo"}
@@ -119,7 +119,7 @@
         (is (= 200 (:status resp)))
         (is (= {"service_version" "1.1.0"
                 "service_status_version" 2
-                "is_running" true
+                "is_running" "true"
                 "detail_level" "critical"
                 "status" "foo status 2 :critical"
                 "service_name" "foo"}
@@ -129,7 +129,7 @@
         (is (= 200 (:status resp)))
         (is (= {"service_version" "1.1.0"
                 "service_status_version" 1
-                "is_running" true
+                "is_running" "true"
                 "detail_level" "info"
                 "status" "foo status 1 :info"
                 "service_name" "foo"}

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -60,30 +60,30 @@
       (let [resp (http-client/get "http://localhost:8180/status/v1/services")
             body (json/parse-string (slurp (:body resp)))]
         (is (= 200 (:status resp)))
-        (is (= {"bar" {"service-version" "0.1.0"
-                       "service-status-version" 1
-                       "is-running" false
-                       "detail-level" "info"
+        (is (= {"bar" {"service_version" "0.1.0"
+                       "service_status_version" 1
+                       "is_running" false
+                       "detail_level" "info"
                        "status" "bar status 1 :info"}
-                "foo" {"service-version" "1.1.0"
-                       "service-status-version" 2
-                       "is-running" true
-                       "detail-level" "info"
+                "foo" {"service_version" "1.1.0"
+                       "service_status_version" 2
+                       "is_running" true
+                       "detail_level" "info"
                        "status" "foo status 2 :info"}}
                body))))
     (testing "uses status level from query param"
       (let [resp (http-client/get "http://localhost:8180/status/v1/services?level=debug")
             body (json/parse-string (slurp (:body resp)))]
         (is (= 200 (:status resp)))
-        (is (= {"bar" {"service-version" "0.1.0"
-                       "service-status-version" 1
-                       "is-running" false
-                       "detail-level" "debug"
+        (is (= {"bar" {"service_version" "0.1.0"
+                       "service_status_version" 1
+                       "is_running" false
+                       "detail_level" "debug"
                        "status" "bar status 1 :debug"}
-                "foo" {"service-version" "1.1.0"
-                       "service-status-version" 2
-                       "is-running" true
-                       "detail-level" "debug"
+                "foo" {"service_version" "1.1.0"
+                       "service_status_version" 2
+                       "is_running" true
+                       "detail_level" "debug"
                        "status" "foo status 2 :debug"}}
                body))))))
 
@@ -107,42 +107,42 @@
     (testing "returns service information for service that has registered a callback"
       (let [resp (http-client/get "http://localhost:8180/status/v1/services/foo")]
         (is (= 200 (:status resp)))
-        (is (= {"service-version" "1.1.0"
-                "service-status-version" 2
-                "is-running" true
-                "detail-level" "info"
+        (is (= {"service_version" "1.1.0"
+                "service_status_version" 2
+                "is_running" true
+                "detail_level" "info"
                 "status" "foo status 2 :info"
-                "service-name" "foo"}
+                "service_name" "foo"}
                (json/parse-string (slurp (:body resp)))))))
     (testing "uses status level query param"
       (let [resp (http-client/get "http://localhost:8180/status/v1/services/foo?level=critical")]
         (is (= 200 (:status resp)))
-        (is (= {"service-version" "1.1.0"
-                "service-status-version" 2
-                "is-running" true
-                "detail-level" "critical"
+        (is (= {"service_version" "1.1.0"
+                "service_status_version" 2
+                "is_running" true
+                "detail_level" "critical"
                 "status" "foo status 2 :critical"
-                "service-name" "foo"}
+                "service_name" "foo"}
                (json/parse-string (slurp (:body resp)))))))
-    (testing "uses service-status-version query param"
-      (let [resp (http-client/get "http://localhost:8180/status/v1/services/foo?service-status-version=1")]
+    (testing "uses service_status_version query param"
+      (let [resp (http-client/get "http://localhost:8180/status/v1/services/foo?service_status_version=1")]
         (is (= 200 (:status resp)))
-        (is (= {"service-version" "1.1.0"
-                "service-status-version" 1
-                "is-running" true
-                "detail-level" "info"
+        (is (= {"service_version" "1.1.0"
+                "service_status_version" 1
+                "is_running" true
+                "detail_level" "info"
                 "status" "foo status 1 :info"
-                "service-name" "foo"}
+                "service_name" "foo"}
                (json/parse-string (slurp (:body resp)))))))
-    (testing "returns unknown for is-running if not provided in callback fn"
+    (testing "returns unknown for is_running if not provided in callback fn"
       (let [resp (http-client/get "http://localhost:8180/status/v1/services/baz")]
         (is (= 200 (:status resp)))
-        (is (= {"service-version" "0.2.0"
-                "service-status-version" 1
-                "is-running" "unknown"
-                "detail-level" "info"
+        (is (= {"service_version" "0.2.0"
+                "service_status_version" 1
+                "is_running" "unknown"
+                "detail_level" "info"
                 "status" nil
-                "service-name" "baz"}
+                "service_name" "baz"}
                (json/parse-string (slurp (:body resp)))))))
     (testing "returns a 404 for service not registered with the status service"
       (let [resp (http-client/get "http://localhost:8180/status/v1/services/notfound")]
@@ -162,15 +162,15 @@
                (json/parse-string (slurp (:body resp)))))))
     (testing "returns a 400 when a non-integer status-version is queried for"
       (let [resp (http-client/get (str "http://localhost:8180/status/v1/"
-                                       "services/foo?service-status-version=abc"))]
+                                       "services/foo?service_status_version=abc"))]
         (is (= 400 (:status resp)))
         (is (= {"error" {"type"    "request-data-invalid"
-                         "message" (str "Invalid service-status-version. "
+                         "message" (str "Invalid service_status_version. "
                                         "Should be an integer but was abc")}}
                (json/parse-string (slurp (:body resp)))))))
     (testing "returns a 400 when a non-existent status-version is queried for"
       (let [resp (http-client/get (str "http://localhost:8180/status/v1/"
-                                        "services/foo?service-status-version=3"))]
+                                        "services/foo?service_status_version=3"))]
         (is (= 400 (:status resp)))
         (is (= {"error" {"type"    "service-status-version-not-found"
                          "message" (str "No status function with version 3 "

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -63,10 +63,12 @@
         (is (= {"bar" {"service-version" "0.1.0"
                        "service-status-version" 1
                        "is-running" false
+                       "detail-level" "info"
                        "status" "bar status 1 :info"}
                 "foo" {"service-version" "1.1.0"
                        "service-status-version" 2
                        "is-running" true
+                       "detail-level" "info"
                        "status" "foo status 2 :info"}}
                body))))
     (testing "uses status level from query param"
@@ -76,10 +78,12 @@
         (is (= {"bar" {"service-version" "0.1.0"
                        "service-status-version" 1
                        "is-running" false
+                       "detail-level" "debug"
                        "status" "bar status 1 :debug"}
                 "foo" {"service-version" "1.1.0"
                        "service-status-version" 2
                        "is-running" true
+                       "detail-level" "debug"
                        "status" "foo status 2 :debug"}}
                body))))))
 
@@ -106,6 +110,7 @@
         (is (= {"service-version" "1.1.0"
                 "service-status-version" 2
                 "is-running" true
+                "detail-level" "info"
                 "status" "foo status 2 :info"
                 "service-name" "foo"}
                (json/parse-string (slurp (:body resp)))))))
@@ -115,6 +120,7 @@
         (is (= {"service-version" "1.1.0"
                 "service-status-version" 2
                 "is-running" true
+                "detail-level" "critical"
                 "status" "foo status 2 :critical"
                 "service-name" "foo"}
                (json/parse-string (slurp (:body resp)))))))
@@ -124,6 +130,7 @@
         (is (= {"service-version" "1.1.0"
                 "service-status-version" 1
                 "is-running" true
+                "detail-level" "info"
                 "status" "foo status 1 :info"
                 "service-name" "foo"}
                (json/parse-string (slurp (:body resp)))))))
@@ -133,6 +140,7 @@
         (is (= {"service-version" "0.2.0"
                 "service-status-version" 1
                 "is-running" "unknown"
+                "detail-level" "info"
                 "status" nil
                 "service-name" "baz"}
                (json/parse-string (slurp (:body resp)))))))


### PR DESCRIPTION
This PR makes the following changes:
- unwrap exceptions from pmap so that they can be handled by our middleware
- add an `:is_running` key to the status service output
- add a `:detail_level` key to the status service output
- add a schema for the `StatusCallbackResponse`
- change hyphens to underscores in JSON output
