### PR TITLE
(maint) Update error maps to be more inline with convention

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
@@ -17,7 +17,7 @@
           (catch #(contains? #{:request-data-invalid :service-status-version-not-found}
                              (:type %)) e
             {:status 400
-             :body {:error e}}))))
+             :body e}))))
 
 (defn wrap-schema-errors
   "A ring middleware that catches schema errors and returns a 500
@@ -29,9 +29,9 @@
            (let [message (.getMessage e)]
              (if (re-find #"does not match schema" message)
                {:status 500
-                :body {:error {:type :application-error
-                               :message (str "Something unexpected happened: "
-                                             (select-keys (.getData e) [:error :value :type]))}}}
+                :body {:type :application-error
+                       :message (str "Something unexpected happened: "
+                                     (select-keys (.getData e) [:error :value :type]))}}
                ;; re-throw exceptions that aren't schema errors
                (throw e)))))))
 
@@ -44,5 +44,5 @@
          (catch Exception e
            (log/error e "Error on server")
            {:status 500
-            :body {:error {:type :application-error
-                           :message (str "Error on server: " e)}}}))))
+            :body {:type :application-error
+                   :message (str "Error on server: " e)}}))))

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -212,9 +212,9 @@
               {:status 200
                :body (assoc status :service_name service-name)})
             {:status 404
-             :body {:error {:type :service-not-found
-                            :message (str "No status information found for service "
-                                       service-name)}}}))))))
+             :body {:type :service-not-found
+                    :message (str "No status information found for service "
+                               service-name)}}))))))
 
 (defn build-handler [status-fns]
   (-> (build-routes status-fns)

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -147,8 +147,8 @@
     (testing "returns a 404 for service not registered with the status service"
       (let [resp (http-client/get "http://localhost:8180/status/v1/services/notfound")]
         (is (= 404 (:status resp)))
-        (is (= {"error" {"type" "service-not-found"
-                         "message" "No status information found for service notfound"}}
+        (is (= {"type" "service-not-found"
+                "message" "No status information found for service notfound"}
               (json/parse-string (slurp (:body resp)))))))))
 
 (deftest error-handling-test
@@ -157,22 +157,22 @@
     (testing "returns a 400 when an invalid level is queried for"
       (let [resp (http-client/get "http://localhost:8180/status/v1/services?level=bar")]
         (is (= 400 (:status resp)))
-        (is (= {"error" {"type" "request-data-invalid"
-                         "message" "Invalid level: :bar"}}
+        (is (= {"type" "request-data-invalid"
+                "message" "Invalid level: :bar"}
               (json/parse-string (slurp (:body resp)))))))
     (testing "returns a 400 when a non-integer status-version is queried for"
       (let [resp (http-client/get (str "http://localhost:8180/status/v1/"
                                     "services/foo?service_status_version=abc"))]
         (is (= 400 (:status resp)))
-        (is (= {"error" {"type"    "request-data-invalid"
-                         "message" (str "Invalid service_status_version. "
-                                     "Should be an integer but was abc")}}
+        (is (= {"type"    "request-data-invalid"
+                "message" (str "Invalid service_status_version. "
+                            "Should be an integer but was abc")}
               (json/parse-string (slurp (:body resp)))))))
     (testing "returns a 400 when a non-existent status-version is queried for"
       (let [resp (http-client/get (str "http://localhost:8180/status/v1/"
                                     "services/foo?service_status_version=3"))]
         (is (= 400 (:status resp)))
-        (is (= {"error" {"type"    "service-status-version-not-found"
-                         "message" (str "No status function with version 3 "
-                                     "found for service foo")}}
+        (is (= {"type"    "service-status-version-not-found"
+                "message" (str "No status function with version 3 "
+                            "found for service foo")}
               (json/parse-string (slurp (:body resp)))))))))


### PR DESCRIPTION
Most other projects at PL seem to have standardized on returning a map with
:kind and :msg keys for errors for http responses. This commit brings the
status service in line with that convention.
