### PR TITLE
(TK-217) Add status level comparison functions

### DIFF
--- a/documentation/developers.md
+++ b/documentation/developers.md
@@ -30,6 +30,33 @@ Code sample:
       v1-status-callback)
     context))
 ```
+
+
+## Implementing Your Status Function
+
+The `puppetlabs.trapperkeeper.services.status.status-core` namespace contains
+some utilities to aid in the implementation of your status functions.  In
+particular, the `level->int` function defines an ordering for status levels as
+`:critical < :info < :debug`, and the `compare-levels` function can be used to 
+compare status levels.  This is especially useful in conjunction with the 
+`cond->` macro from `clojure.core`.  Here's an example of how a status function 
+might be implemented to utilize the `compare-levels` function:
+```clj
+(require '[puppetlabs.trapperkeeper.services.status.status-core :as status-core])
+
+(defn my-status
+  [level]
+  (let [level>= (partial status-core/compare-levels >= level)]
+    {:is-running true
+     :status (cond-> {:this-is-critical "foo"}
+               (level>= :info) (assoc :bar "bar"
+                                      :baz "baz")
+               (level>= :debug) (assoc :x "x"
+                                       :y "y"
+                                       :z "y"))}))
+```
+
+
 ## Details
 
 See [Query API](./query-api.md) and [Wire Format](./wire-formats.md) for details

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -95,6 +95,21 @@
                  version))))
     version))
 
+(defn level->int
+  "Returns an integer which represents the given status level.
+   The ordering of levels is :critical < :info < :debug."
+  [level]
+  (case level
+    :critical 0
+    :info 1
+    :debug 2))
+
+(defn compare-levels
+  "Converts the two status levels to integers using level->int and then
+   invokes f, passing the two integers as arguments.  Especially useful for
+   comparing two status levels."
+  [f level1 level2]
+  (f (level->int level1) (level->int level2)))
 
 (schema/defn service-status-map :- ServiceInfo
   [svc-version status-version status-fn]

--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -8,7 +8,11 @@
 (defprotocol StatusService
   (register-status [this service-name service-version status-version status-fn]
     "Register a status callback function for a service by adding it to the
-    status service context."))
+    status service context.  status-fn must be a function of arity 1 which takes
+    the status level as a keyword and returns the status information for
+    the given level.  The return value of the callback function must satisfy
+    the puppetlabs.trapperkeeper.services.status.status-core/StatusCallbackResponse
+    schema."))
 
 (defservice status-service
   StatusService


### PR DESCRIPTION
Define numeric values for status levels.

Add a level>= function to aid in the implementation of status functions
which return additive information across status levels.
