### PR TITLE
(maint) Remove postgresql dependency.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,6 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/java.jdbc "0.3.7"]
                  [cheshire "5.3.1"]
-                 [org.postgresql/postgresql "9.3-1100-jdbc41"]
                  [prismatic/schema "0.4.0"]
                  [ring/ring-json "0.3.1" :exclusions [ring/ring-core]]
                  [ring/ring-defaults "0.1.5"]


### PR DESCRIPTION
As downstream consumers that want to use the database status check will
supply their own JDBC drivers, there's no need to include this
dependency.
