### PR TITLE
(maint) No DB, disk-writable? takes path

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,6 @@
   :exclusions [org.clojure/clojure]
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/java.jdbc "0.3.7"]
                  [cheshire "5.3.1"]
                  [prismatic/schema "0.4.0"]
                  [ring/ring-json "0.3.1" :exclusions [ring/ring-core]]

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,6 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/java.jdbc "0.3.7"]
                  [cheshire "5.3.1"]
-                 [org.postgresql/postgresql "9.3-1100-jdbc41"]
                  [prismatic/schema "0.4.0"]
                  [ring/ring-json "0.3.1" :exclusions [ring/ring-core]]
                  [ring/ring-defaults "0.1.5"]

--- a/src/puppetlabs/trapperkeeper/services/status/check.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/check.clj
@@ -1,28 +1,30 @@
 (ns puppetlabs.trapperkeeper.services.status.check
   "Shared status check functions."
-  (:require [clojure.java.jdbc :as sql])
   (:import [java.io File IOException]))
 
-(defn db-up?
-  [db-spec]
-  (try (let [select-42 "SELECT (a - b) AS answer FROM (VALUES ((7 * 7), 7)) AS x(a, b)"
-             [{:keys [answer]}] (sql/query db-spec [select-42])]
-         (= answer 42))
-    (catch Exception _
-      false)))
-
 (defn disk-writable?
-  []
-  (if-let [temp-file (try (File/createTempFile "tk-disk-check" ".txt")
-                       (catch IOException _ nil))]
-    (let [payload (apply str (map char (repeatedly 4095 #(rand-nth (range 97 123)))))]
-      (try
-        (spit temp-file payload)
-        (= (slurp temp-file) payload)
-        (catch Exception _
-          false)
-        (finally
-          (try (.delete temp-file)
-            (catch IOException _
-              false)))))
-    false))
+  "Given a directory, check whether the FS that the directory is in seems
+  healthy by writing 4k random letters to a file in that directory, and then
+  read them back in. If what was read matches what was written, then return
+  true; if there's a mismatch or anything goes wrong in the process, return
+  false.
+
+  Since this check involves writing to disk, it may not be appropriate to put at
+  a high status check level like :critical or :info."
+  [directory]
+  (let [rand-letter #(char (rand-nth (range 97 123)))
+        fname (str "tk-disk-check-" (apply str (repeatedly 10 rand-letter)) ".txt")]
+    (if-let [file (File. directory fname)]
+      (let [payload (apply str (repeatedly 4095 rand-letter))]
+        (try
+          (when (.exists file)
+            (.delete file))
+          (spit file payload)
+          (= (slurp file) payload)
+          (catch Exception _
+            false)
+          (finally
+            (try (.delete file)
+              (catch IOException _
+                false)))))
+      false)))

--- a/test/puppetlabs/trapperkeeper/services/status/check_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/check_test.clj
@@ -1,57 +1,34 @@
 (ns puppetlabs.trapperkeeper.services.status.check-test
-  (:require [clojure.java.jdbc :as sql]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [puppetlabs.trapperkeeper.services.status.check :refer :all]))
 
-(deftest db-up?-test
-  (testing "db-up?"
-    (testing "connects to a database, runs an arithmetic query, and checks the result"
-      (let [!query (atom nil)
-            !db (atom nil)
-            db-spec {:conninfo "postgresql://user:pass@localhost:5432/db"}]
-        (with-redefs [sql/query (fn [db sql-vec]
-                                  (reset! !db db)
-                                  (reset! !query sql-vec)
-                                  [{:answer 42}])]
-          (is (db-up? db-spec))
-          (is (= db-spec @!db))
-          (is (= ["SELECT (a - b) AS answer FROM (VALUES ((7 * 7), 7)) AS x(a, b)"]
-                 @!query)))))
-
-    (testing "returns false if the query function throws an exception"
-      (with-redefs [sql/query (fn [_ _] (throw (Exception. "what DB?")))]
-        (is (false? (db-up? nil)))))
-
-    (testing "returns false if the arithmetic doesn't check out"
-      (with-redefs [sql/query (fn [_ _] [{:answer 49}])]
-        (is (false? (db-up? nil)))))))
-
 (deftest disk-writable?-test
-  (testing "disk-writable?"
-    (testing "writes to a temp file, checks what was written, and deletes the file."
-      (let [!file (atom nil)
-            !content (atom nil)]
-        (with-redefs [spit (fn [file content]
-                             (reset! !file file)
-                             (reset! !content content)
-                             nil)
-                      slurp (fn [file]
-                              (is (= @!file file))
-                              @!content)]
-          (is (disk-writable?))
-          (is (not (.exists @!file))))))
+  (let [temp-dir (System/getProperty "java.io.tmpdir")]
+    (testing "disk-writable?"
+      (testing "writes to a temp file, checks what was written, and deletes the file."
+        (let [!file (atom nil)
+              !content (atom nil)]
+          (with-redefs [spit (fn [file content]
+                               (reset! !file file)
+                               (reset! !content content)
+                               nil)
+                        slurp (fn [file]
+                                (is (= @!file file))
+                                @!content)]
+            (is (disk-writable? temp-dir))
+            (is (not (.exists @!file))))))
 
-    (testing "returns false if what was read isn't what was written"
-      (with-redefs [spit (constantly nil)
-                    slurp (constantly "foo")]
-        (is (not (disk-writable?)))))
+      (testing "returns false if what was read isn't what was written"
+        (with-redefs [spit (constantly nil)
+                      slurp (constantly "foo")]
+          (is (not (disk-writable? temp-dir)))))
 
-    (testing "returns false if an exception was thrown by spit"
-      (let [!file (atom nil)]
-        (with-redefs [spit (fn [file _]
-                             (reset! !file file)
-                             (throw (Exception. "this isn't real")))]
-          (is (false? (disk-writable?))))
+      (testing "returns false if an exception was thrown by spit"
+        (let [!file (atom nil)]
+          (with-redefs [spit (fn [file _]
+                               (reset! !file file)
+                               (throw (Exception. "this isn't real")))]
+            (is (false? (disk-writable? temp-dir))))
 
-        (testing "but still deletes the file"
-          (is (not (.exists @!file))))))))
+          (testing "but still deletes the file"
+            (is (not (.exists @!file)))))))))


### PR DESCRIPTION
Remove the `db-up?` status check, its tests, the
org.clojure/java.jdbc dependency, and the postgresql JDBC drivers
dependency.

Change the `disk-writable?` check to take a directory argument, and
create the file it writes to & reads from inside that directory, rather
than in the system's temporary directory.
