### PR TITLE
(TK-231) Set JSON content type on responses

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -225,6 +225,7 @@
                          service-status-version)]
             {:status 200
              :body (assoc status :service_name service-name)})
+          ;; else (no service with that name)
           {:status 404
            :body {:type :service-not-found
                   :message (str "No status information found for service "

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -234,8 +234,8 @@
 (defn build-handler [path status-fns]
   (-> (build-routes path status-fns)
     comidi/routes->handler
-    (ring-defaults/wrap-defaults ring-defaults/api-defaults)
     ringutils/wrap-request-data-errors
     ringutils/wrap-schema-errors
     ringutils/wrap-errors
-    ring-json/wrap-json-response))
+    ring-json/wrap-json-response
+    (ring-defaults/wrap-defaults ring-defaults/api-defaults)))

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -219,3 +219,10 @@
                     :y "y"
                     :z "y"}
                   (response->status resp)))))))))
+
+(deftest content-type-test
+  (testing "responses have the 'application/json' content type set"
+    (with-status-service app
+      [foo-service]
+      (let [{:keys [headers]} (http-client/get "http://localhost:8180/status/v1/services/foo")]
+        (is (re-find #"^application/json" (get headers "content-type")))))))


### PR DESCRIPTION
Change the order of middleware application so that the
wrap-json-response middleware adds the content type header first,
resulting in the desired 'application/json' value.
