### PR TITLE
(TK-229) Rename is_running to state

### DIFF
--- a/documentation/developers.md
+++ b/documentation/developers.md
@@ -18,7 +18,7 @@ Code sample:
 (schema/defn ^:always-validate
   v1-status-callback :- status-core/StatusCallbackResponse
   [level :- status-core/ServiceStatusDetailLevel]
-  {:is-running :true
+  {:state :running
    :status (get-basic-status-for-my-service-at-level level)})
 
 (defservice foo-service
@@ -47,7 +47,7 @@ might be implemented to utilize the `compare-levels` function:
 (defn my-status
   [level]
   (let [level>= (partial status-core/compare-levels >= level)]
-    {:is-running true
+    {:state running
      :status (cond-> {:this-is-critical "foo"}
                (level>= :info) (assoc :bar "bar"
                                       :baz "baz")

--- a/documentation/query-api.md
+++ b/documentation/query-api.md
@@ -48,7 +48,7 @@ The response format will be a JSON _Object_, which will look something like this
         "service_version": <service-version>,
         "service_status_version": <service-status-version>,
         "detail_level": <detail-level>,
-        "is_running": <service-state>,
+        "state": <service-state>,
         "status": <any>
         },
      <service-name>: {
@@ -79,7 +79,7 @@ Get the service status of all registered services in an application:
     {
         "puppet-server": {
             "detail_level": "info",
-            "is_running": "true",
+            "state": "running",
             "service_status_version": 1,
             "service_version": "1.0.9-SNAPSHOT",
             "status": {
@@ -90,7 +90,7 @@ Get the service status of all registered services in an application:
 
         "other-service": {
             "detail_level": "info",
-            "is_running": "true",
+            "state": "running",
             "service_status_version": 2,
             "service_version": "0.0.1-SNAPSHOT",
             "status": {
@@ -108,7 +108,7 @@ Get the service status of all registered services in an application, at a
     {
         "puppet-server": {
             "detail_level": "critical",
-            "is_running": "true",
+            "state": "running",
             "service_status_version": 1,
             "service_version": "1.0.9-SNAPSHOT",
             "status": null
@@ -116,7 +116,7 @@ Get the service status of all registered services in an application, at a
 
         "other-service": {
             "detail_level": "info",
-            "is_running": "true",
+            "state": "running",
             "service_status_version": 2,
             "service_version": "0.0.1-SNAPSHOT",
             "status": null
@@ -148,7 +148,7 @@ which will look something like this:
         "service_version": <service-version>,
         "service_status_version": <service-status-version>,
         "detail_level": <detail-level>,
-        "is_running": <service-state>,
+        "state": <service-state>,
         "status": <any>
         }
     }
@@ -166,7 +166,7 @@ Get the service status for a specified service in the application:
     {
         "other-service": {
             "detail_level": "info",
-            "is_running": "true",
+            "state": "running",
             "service_status_version": 2,
             "service_version": "0.0.1-SNAPSHOT",
             "status": {
@@ -184,7 +184,7 @@ version:
     {
         "other-service": {
             "detail_level": "info",
-            "is_running": "true",
+            "state": "running",
             "service_status_version": 1,
             "service_version": "0.0.1-SNAPSHOT",
             "status": {
@@ -202,7 +202,7 @@ version and a specific detail level:
     {
         "other-service": {
             "detail_level": "debug",
-            "is_running": "true",
+            "state": "running",
             "service_status_version": 2,
             "service_version": "0.0.1-SNAPSHOT",
             "status": {

--- a/documentation/wire-formats.md
+++ b/documentation/wire-formats.md
@@ -7,7 +7,7 @@ is not allowed anywhere in the status data.
         "service_version": <service-version>,
         "service_status_version": <service-status-version>,
         "detail_level": <detail-level>,
-        "is_running": <service-state>,
+        "state": <service-state>,
         "status": <any>
         },
      <service-name>: {
@@ -43,7 +43,7 @@ It indicates the version number of each service that is providing status informa
  Services may provide slightly more detail at the `"info"` level.  Services may
  provide very detailed information, suitable for debugging, at the `"debug"` level.
 
-`<service-state>` is a String from the following enumeration: (`"true"`, `"false"`,
+`<service-state>` is a String from the following enumeration: (`"running"`, `"error"`,
  `"unknown"`).  `"unknown"` will be used when there is a problem that is preventing
  the Status Service from getting accurate status information from the specified
  service.

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -15,11 +15,11 @@
 (def ServiceStatusDetailLevel
   (schema/enum :critical :info :debug))
 
-(def IsRunning
-  (schema/enum :true :false :unknown))
+(def State
+  (schema/enum :running :error :unknown))
 
 (def StatusCallbackResponse
-  {:is-running IsRunning
+  {:state State
    :status schema/Any})
 
 (def ServiceInfo
@@ -39,7 +39,7 @@
 (def ServiceStatus
   {:service_version schema/Str
    :service_status_version schema/Int
-   :is_running IsRunning
+   :state State
    :detail_level ServiceStatusDetailLevel
    :status schema/Any})
 
@@ -76,7 +76,7 @@
 
 (schema/defn ^:always-validate nominal?
   [status :- ServiceStatus]
-  (= (:is_running status) :true))
+  (= (:state status) :running))
 
 (schema/defn ^:always-validate all-nominal?
   [statuses :- ServicesStatus]
@@ -140,8 +140,8 @@
   status, the detail level, and the results of calling the status function
   corresponding to the status version specified (or the most recent version if
   not). If the response from the callback function does not include an
-  :is-running key, or returns a value other than true or false, return
-  :unknown for :is-running."
+  :state key, or returns a value other than true or false, return
+  :unknown for :state."
   ([service-name :- schema/Str
     service :- [ServiceInfo]
     level :- ServiceStatusDetailLevel]
@@ -163,13 +163,13 @@
                             service-name)}))
       (let [callback-resp ((:status-fn status) level)
             data (:status callback-resp)
-            is-running (if-not (schema/check IsRunning (:is-running callback-resp))
-                         (:is-running callback-resp)
+            state (if-not (schema/check State (:state callback-resp))
+                         (:state callback-resp)
                          :unknown)]
         {:service_version (:service-version status)
          :service_status_version (:service-status-version status)
          :detail_level level
-         :is_running is-running
+         :state state
          :status data}))))
 
 (schema/defn ^:always-validate call-status-fns :- ServicesStatus


### PR DESCRIPTION
Rename `is_running` to `state` and possible values from `true`, `false`, and `unknown`
to `running`, `error`, and `unknown`.
