### PR TITLE
(maint) Fix dependency issue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [cheshire "5.3.1"]
                  [prismatic/schema "0.4.0"]
                  [ring/ring-json "0.3.1" :exclusions [ring/ring-core]]
-                 [ring/ring-defaults "0.1.5"]
+                 [ring/ring-defaults "0.1.5" :exclusions [javax.servlet/servlet-api]]
                  [slingshot "0.12.2"]
                  [puppetlabs/kitchensink ~ks-version :exclusions [clj-time]]
                  [puppetlabs/trapperkeeper ~tk-version :exclusions [clj-time org.clojure/tools.macro]]


### PR DESCRIPTION
Other projects using trapperkeeper-status were exploding because it was
transitively pulling in a really old version of the java servlet. This commit
excludes that dependency, so this should no longer be an issue.
