### PR TITLE
 (TK-230) Implement "simple" endpoint for plaintext responses

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/ringutils.clj
@@ -2,47 +2,85 @@
 ;; probably be moved into a shared library or some such.
 (ns puppetlabs.trapperkeeper.services.status.ringutils
   (:require [clojure.tools.logging :as log]
+            [cheshire.core :as json]
+            [ring.util.response :as response]
+            [schema.core :as schema]
             [slingshot.slingshot :refer [try+]]
             [puppetlabs.kitchensink.core :as ks]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Public
+;;; Schemas
 
-(defn wrap-request-data-errors
+(def ResponseType (schema/enum :json :plain))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+(defn json-response [status body]
+  (-> body
+      json/encode
+      response/response
+      (response/status status)
+      (response/content-type "application/json; charset=utf-8")))
+
+(defn plain-response [status body]
+  (-> body
+      response/response
+      (response/status status)
+      (response/content-type "text/plain; charset=utf-8")))
+
+(schema/defn ^:always-validate wrap-request-data-errors
   "A ring middleware that catches slingshot errors of :type
   :request-dava-invalid and returns a 400."
-  [handler]
-  (fn [request]
-    (try+ (handler request)
-          (catch #(contains? #{:request-data-invalid :service-status-version-not-found}
-                             (:type %)) e
-            {:status 400
-             :body e}))))
+  [handler type :- ResponseType]
+  (let [code 400
+        response (fn [e]
+                   (case type
+                     :json (json-response code e)
+                     :plain (plain-response code (:message e))))]
+    (fn [request]
+      (try+ (handler request)
+            (catch
+                #(contains? #{:request-data-invalid :service-status-version-not-found}
+                            (:type %))
+                e
+              (response e))))))
 
-(defn wrap-schema-errors
+(schema/defn ^:always-validate wrap-schema-errors
   "A ring middleware that catches schema errors and returns a 500
   response with the details"
-  [handler]
-  (fn [request]
-    (try (handler request)
-         (catch clojure.lang.ExceptionInfo e
-           (let [message (.getMessage e)]
-             (if (re-find #"does not match schema" message)
-               {:status 500
-                :body {:type :application-error
-                       :message (str "Something unexpected happened: "
-                                     (select-keys (.getData e) [:error :value :type]))}}
-               ;; re-throw exceptions that aren't schema errors
-               (throw e)))))))
+  [handler type :- ResponseType]
+  (let [code 500
+        response (fn [e]
+                   (let [msg (str "Something unexpected happened: "
+                                  (select-keys (.getData e) [:error :value :type]))]
+                     (case type
+                       :json (json-response code
+                               {:type :application-error
+                                :message msg})
+                       :plain (plain-response code msg))))]
+    (fn [request]
+      (try (handler request)
+           (catch clojure.lang.ExceptionInfo e
+             (let [message (.getMessage e)]
+               (if (re-find #"does not match schema" message)
+                 (response e)
+                 ;; re-throw exceptions that aren't schema errors
+                 (throw e))))))))
 
-(defn wrap-errors
+(schema/defn ^:always-validate wrap-errors
   "A ring middleware that catches all otherwise uncaught errors and
   returns a 500 response with the error message"
-  [handler]
-  (fn [request]
-    (try (handler request)
-         (catch Exception e
-           (log/error e "Error on server")
-           {:status 500
-            :body {:type :application-error
-                   :message (str "Error on server: " e)}}))))
+  [handler type :- ResponseType]
+  (let [code 500
+        response (fn [e]
+                   (let [msg (str "Error on server: " e)]
+                     (case type
+                       :json (json-response code
+                               {:type :application-error
+                                :message msg})
+                       :plain (plain-response code msg))))]
+    (fn [request]
+      (try (handler request)
+           (catch Exception e
+             (log/error e "Error on server")
+             (response e))))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -244,6 +244,69 @@
                             "found for service foo")}
               (json/parse-string (slurp (:body resp)))))))))
 
+
+(deftest simple-routes-params-ignoring-test
+  (with-status-service app
+    [foo-service]
+    (testing "ignores bad level"
+      (let [resp (http-client/get "http://localhost:8180/status/v1/simple?level=bar")]
+        (is (= 200 (:status resp)))
+        (is (= "running" (slurp (:body resp))))))
+    (testing "ignores alphabetic service_status_version"
+      (let [resp (http-client/get (str "http://localhost:8180/status/v1/"
+                                       "simple/foo?service_status_version=abc"))]
+        (is (= 200 (:status resp)))
+        (is (= "running" (slurp (:body resp))))))
+    (testing "ignores non-existent service_status_version"
+      (let [resp (http-client/get (str "http://localhost:8180/status/v1/"
+                                       "simple/foo?service_status_version=3"))]
+        (is (= 200 (:status resp)))
+        (is (= "running" (slurp (:body resp))))))))
+
+(deftest simple-routes-test
+  (testing "when calling the simple routes"
+    (testing "for all services"
+      (testing "and all services are :running"
+        (with-status-service app
+          [foo-service bar-service]
+          (let [resp (http-client/get "http://localhost:8180/status/v1/simple")]
+            (is (= 200 (:status resp)))
+            (is (= "running" (slurp (:body resp)))))))
+
+      (testing "and a service is :error"
+        (with-status-service app
+          [foo-service baz-service fail-service]
+          (let [resp (http-client/get "http://localhost:8180/status/v1/simple")]
+            (is (= 503 (:status resp)))
+            (is (= "error" (slurp (:body resp)))))))
+
+      (testing "and a service is :unknown"
+        (with-status-service app
+          [foo-service baz-service]
+          (let [resp (http-client/get "http://localhost:8180/status/v1/simple")]
+            (is (= 503 (:status resp)))
+            (is (= "unknown" (slurp (:body resp))))))))
+
+    (testing "for a single service"
+      (with-status-service app
+        [foo-service baz-service fail-service]
+        (testing "and it is :running"
+          (let [resp (http-client/get "http://localhost:8180/status/v1/simple/foo")]
+            (is (= 200 (:status resp)))
+            (is (= "running" (slurp (:body resp))))))
+        (testing "and it is :unknown"
+          (let [resp (http-client/get "http://localhost:8180/status/v1/simple/baz")]
+            (is (= 503 (:status resp)))
+            (is (= "unknown" (slurp (:body resp))))))
+        (testing "and it is :error"
+          (let [resp (http-client/get "http://localhost:8180/status/v1/simple/fail")]
+            (is (= 503 (:status resp)))
+            (is (= "error" (slurp (:body resp))))))
+        (testing "and it does not exist"
+          (let [resp (http-client/get "http://localhost:8180/status/v1/simple/kafka")]
+            (is (= 404 (:status resp)))
+            (is (= "not found: kafka" (slurp (:body resp))))))))))
+
 (defn response->status
   [resp]
   (:status (json/parse-string (slurp (:body resp)) true)))


### PR DESCRIPTION
This commit adds two new endpoints to tk-status that support no query
parameters and return only simple plaintext messages and relevant status
codes.

Note that in order to handle the potential for either plaintext or
json responses in our error handling middleware, there is a mix of
compojure and comidi functions when definiing tk-status's ring handler.
We use compojure's functions to compose handlers which have been
generated by comidi and then had middleware applied to them.

We required this because we could no longer apply the same list of
middleware to the entire ring handler (since now the json routes and
plaintext routes required different sets of middleware).
