### PR TITLE
(MAINT) add exclusion for obsolete servlet-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.1
+
+This is a maintenance / bugfix release.
+
+* Exclude the obsolete servlet-api dependency from ring-defaults, to avoid
+  classpath issues with multiple copies of the servlet API in downstream
+  projects.
+
 ## 0.3.0
 
 This is a feature release.

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,10 @@
 
                  [cheshire "5.3.1"]
                  [prismatic/schema "1.0.4"]
-                 [ring/ring-defaults "0.1.5"]
+                 ;; ring-defaults brings in a bad, old version of the servlet-api, which
+                 ;; now has a new artifact name, so we need to use exclusions here
+                 [ring/ring-defaults "0.1.5" :exclusions [javax.servlet/servlet-api]]
+
                  [slingshot "0.12.2"]
                  [trptcolin/versioneer "0.2.0"]
                  [org.clojure/java.jmx "0.3.1"]

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,11 @@
                  [cheshire "5.3.1"]
                  [prismatic/schema "1.0.4"]
                  ;; ring-defaults brings in a bad, old version of the servlet-api, which
-                 ;; now has a new artifact name, so we need to use exclusions here
+                 ;; now has a new artifact name (javax.servlet/javax.servlet-api).  If we
+                 ;; don't exclude the old one here, they'll both be brought in, and consumers
+                 ;; will be subject to the whims of which one shows up on the classpath first.
+                 ;; thus, we need to use exclusions here, even though we'd normally resolve
+                 ;; this type of thing by just specifying a fixed dependency version.
                  [ring/ring-defaults "0.1.5" :exclusions [javax.servlet/servlet-api]]
 
                  [slingshot "0.12.2"]


### PR DESCRIPTION
ring-defaults has a dependency on an old version of the javax
servlet API.  This artifact has a different name than new versions
of the servlet API, which means that lein won't detect a conflict,
and you will end up with a classpath that has multiple copies of
the servlet API in it, which will cause all kinds of indecipherable
errors, and that ain't no good time for nobody.

This commit adds an exclusion to prevent that terrible old dependency
from being brought in transitively by consumers of tk-status.
