### PR TITLE
(PE-14296) (TK-324) Remove semver check

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,6 @@
                  [trptcolin/versioneer "0.2.0"]
                  [org.clojure/java.jmx "0.3.1"]
 
-                 [grimradical/clj-semver "0.3.0"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/comidi "0.3.1"]]

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -7,7 +7,6 @@
             [puppetlabs.comidi :as comidi]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.trapperkeeper.services.status.ringutils :as ringutils]
-            [clj-semver.core :as semver]
             [trptcolin.versioneer.core :as versioneer]
             [clojure.java.jmx :as jmx])
   (:import (java.net URL)
@@ -53,8 +52,7 @@
 (def ServicesStatus
   {schema/Str ServiceStatus})
 
-(def SemVerVersion
-  (schema/pred semver/valid-format? "semver"))
+(def Version schema/Str)
 
 (def StatusProxyConfig
   {:proxy-target-url schema/Str
@@ -158,7 +156,7 @@
   (every? nominal? (vals statuses)))
 
 (schema/defn ^:always-validate
-  get-artifact-version :- SemVerVersion
+  get-artifact-version :- schema/Str
   "Utility function that services can use to get a value to pass in as their
   `service-version` when registering a status callback.  `group-id` and
   `artifact-id` should match the maven/leiningen identifiers for the project
@@ -170,12 +168,6 @@
                (format "Unable to find version number for '%s/%s'"
                  group-id
                  artifact-id))))
-    (when-not (semver/valid-format? version)
-      (throw (IllegalStateException.
-               (format "Service '%s/%s' has version that does not comply with semver: '%s'"
-                 group-id
-                 artifact-id
-                 version))))
     version))
 
 (def status-service-version

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -4,7 +4,6 @@
             [schema.test :as schema-test]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
             [puppetlabs.trapperkeeper.services.status.status-core :refer :all]
-            [trptcolin.versioneer.core :as versioneer]
             [slingshot.test]
             [puppetlabs.kitchensink.core :as ks]))
 
@@ -15,16 +14,9 @@
     ;; This test coverage isn't very thorough, but anything beyond this would
     ;; really just be testing the underlying libraries that we use to
     ;; implement it.
-    (is (nil? (schema/check
-                SemVerVersion
-                (get-artifact-version "puppetlabs" "trapperkeeper-status"))))
     (is (thrown-with-msg? IllegalStateException
           #"Unable to find version number for"
-          (get-artifact-version "fake-group" "artifact-that-does-not-exist")))
-    (with-redefs [versioneer/get-version (constantly "bad-version-string")]
-      (is (thrown-with-msg? IllegalStateException
-            #"does not comply with semver"
-            (get-artifact-version "puppetlabs" "trapperkeeper-status"))))))
+          (get-artifact-version "fake-group" "artifact-that-does-not-exist")))))
 
 (deftest update-status-context-test
   (let [status-fns (atom {})]


### PR DESCRIPTION
We were in no way taking advantage of the semver check we used when
getting an artifact's version and it was breaking against some of our
artifacts that use a fourth 'build' digit in versions.
