### PR TITLE
(maint) Make service lifecycle idempotent

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -147,6 +147,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
+(def status-service-name "status-service")
+
 (schema/defn ^:always-validate nominal? :- schema/Bool
   [status :- ServiceStatus]
   (= (:state status) :running))
@@ -204,6 +206,13 @@
     status-version)
   (let [status-map (service-status-map svc-version status-version status-fn)]
     (swap! status-fns-atom update-in [svc-name] conj status-map)))
+
+(schema/defn ^:always-validate dissoc-status-context! :- nil
+  "Remove a key from the :status-fns atom in the service context"
+  [status-fns-atom :- clojure.lang.Atom
+   svc-name :- schema/Str]
+  (swap! status-fns-atom dissoc svc-name)
+  nil)
 
 (schema/defn ^:always-validate guarded-status-fn-call :- StatusCallbackResponse
   "Given a status check function, a status detail level, and a timeout in

--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -23,7 +23,7 @@
     (assoc context :status-fns (atom {})))
 
   (start [this context]
-    (register-status this "status-service"
+    (register-status this status-core/status-service-name
                      status-core/status-service-version
                      1
                      (partial status-core/v1-status))
@@ -31,6 +31,11 @@
     (let [path (get-route this)
           handler (status-core/build-handler path (deref (:status-fns context)))]
       (add-ring-handler this handler))
+    context)
+
+  (stop [this context]
+    (status-core/dissoc-status-context! (:status-fns context)
+                                        status-core/status-service-name)
     context)
 
   (register-status [this service-name service-version status-version status-fn]


### PR DESCRIPTION
This commit allows the status service to be restarted. Prior to this
commit, the status service's `start` function would attempt to re-add
the status service's own function to `:status-fns`, resulting in a
validation error.
