### PR TITLE
(TK-335) Make service lifecycle idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.3
+
+This is a maintenance / bugfix release.
+
+* Allow trapperkeeper's `stop` and `start` functions to be called on the status
+  service without error by cleaning up context state manually.
+
 ## 0.3.2
 
 This is a maintenance / bugfix release.

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -147,6 +147,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
+(def status-service-name "status-service")
+
 (schema/defn ^:always-validate nominal? :- schema/Bool
   [status :- ServiceStatus]
   (= (:state status) :running))
@@ -204,6 +206,12 @@
     status-version)
   (let [status-map (service-status-map svc-version status-version status-fn)]
     (swap! status-fns-atom update-in [svc-name] conj status-map)))
+
+(schema/defn ^:always-validate reset-status-context! :- nil
+  "Remove a key from the :status-fns atom in the service context"
+  [status-fns-atom :- clojure.lang.Atom]
+  (reset! status-fns-atom {})
+  nil)
 
 (schema/defn ^:always-validate guarded-status-fn-call :- StatusCallbackResponse
   "Given a status check function, a status detail level, and a timeout in

--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -23,7 +23,7 @@
     (assoc context :status-fns (atom {})))
 
   (start [this context]
-    (register-status this "status-service"
+    (register-status this status-core/status-service-name
                      status-core/status-service-version
                      1
                      (partial status-core/v1-status))
@@ -31,6 +31,10 @@
     (let [path (get-route this)
           handler (status-core/build-handler path (deref (:status-fns context)))]
       (add-ring-handler this handler))
+    context)
+
+  (stop [this context]
+    (status-core/reset-status-context! (:status-fns context))
     context)
 
   (register-status [this service-name service-version status-version status-fn]

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -3,8 +3,8 @@
             [cheshire.core :as json]
             [schema.test :as schema-test]
             [puppetlabs.http.client.sync :as http-client]
-            [puppetlabs.trapperkeeper.services :refer [defservice service]]
-            [puppetlabs.trapperkeeper.app :refer [get-service]]
+            [puppetlabs.trapperkeeper.services :refer [defservice service service-context]]
+            [puppetlabs.trapperkeeper.app :refer [get-service] :as tka]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer :all]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
             [puppetlabs.trapperkeeper.services.status.status-service :refer [status-service get-status]]
@@ -419,4 +419,15 @@
                  :service_version status-core/status-service-version
                  :state "running"}
                 (dissoc body :status)))
-         (is (map? (get-in body [:status :experimental :jvm-metrics]))))))))
+         (is (map? (get-in body [:status :experimental :jvm-metrics])))))
+     (testing "and does so idempotently"
+       (let [get-status-status #(-> (get-service app :StatusService)
+                                    service-context
+                                    :status-fns
+                                    deref
+                                    (get status-core/status-service-name))]
+         (is (not (nil? (get-status-status))))
+         (tka/stop app)
+         (is (nil? (get-status-status)))
+         (tka/start app)
+         (is (not (nil? (get-status-status)))))))))


### PR DESCRIPTION
This commit allows the status service to be stopped and started (distinct from tk's `restart`). Prior to this
commit, the status service's `start` function would attempt to re-add
the status service's own function to `:status-fns`, resulting in a
validation error.
