### PR TITLE
(TK-298) Bring tk-status docs up to date

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,21 +2,5 @@
 
 * [Querying the Status Service](./query-api.md)
 * [Wire Formats](./wire-formats.md)
+* [Status Proxy Service](./status-proxy-service.md)
 * [Developer Documentation](./developers.md)
-
-## What's Next?
-
-Things that are not finished yet:
-
-* The API; it should not be considered final yet,
-  but it will have to be finalized before the first consuming
-  service ships a version that includes this.  Please provide feedback!
-* Improved error handling (e.g. if one service's status
-  callback fails, that should not prevent us from returning
-  status for other services: see TK-175).
-* Support for a plain-text HTTP endpoint that proxies through
-  to an HTTPS version using configurable certs; this is for
-  use cases involving load balancers and other monitoring
-  devices that don't provide sophisticated SSL configuration
-  capabilities (see TK-176).
-* Finalize internal schemas, improve JSON serialization code.

--- a/documentation/developers.md
+++ b/documentation/developers.md
@@ -31,7 +31,6 @@ Code sample:
     context))
 ```
 
-
 ## Implementing Your Status Function
 
 The `puppetlabs.trapperkeeper.services.status.status-core` namespace contains
@@ -56,6 +55,31 @@ might be implemented to utilize the `compare-levels` function:
                                        :z "y"))}))
 ```
 
+## Exposing the /status endpoint
+
+If you want your registered status functions to be accessible via HTTP(S),
+you need to route the status service accordingly:
+
+```
+webserver: {
+  default: {
+    ssl-port: 9001
+    ssl-cert: /etc/ssl/certs/myhostname.pem
+    ssl-key: /etc/ssl/private_keys/myhostname.pem
+    ssl-ca-cert: /etc/ssl/certs/ca.pem
+    default-server: true
+  }
+}
+
+web-router-service: {
+  "puppetlabs.trapperkeeper.services.status.status-service/status-service": {
+    route: /status
+    server: default
+  }
+}
+```
+
+For information on HTTP serving of the status endpoint, see the [Status Proxy documentation](./status-proxy-service.md).
 
 ## Details
 

--- a/documentation/developers.md
+++ b/documentation/developers.md
@@ -79,7 +79,8 @@ web-router-service: {
 }
 ```
 
-For information on HTTP serving of the status endpoint, see the [Status Proxy documentation](./status-proxy-service.md).
+For information on proxying plaintext `/status` requests to an otherwise HTTPS
+protected server, see the [Status Proxy documentation](./status-proxy-service.md).
 
 ## Details
 

--- a/documentation/query-api.md
+++ b/documentation/query-api.md
@@ -216,12 +216,15 @@ version and a specific detail level:
     }
 
 
-## Simple (plaintext) Endpoints
+## Simple Endpoints
 
 These endpoints are designed for load balancers that don't support any kind of
 JSON parsing or query parameter use. They return simple string bodies (either
 the state of the service in question or a simple error message) and a status
 code relevant to the status result.
+
+If your load balancer *also* needs HTTP instead of HTTPS, you may wish to use the
+[status service proxy](./status-proxy-service.md).
 
 The content type for these endpoints is `text/plain; charset=utf-8`.
 
@@ -255,7 +258,7 @@ No parameters are supported. Defaults to using the _critical_ status level.
 
 ### GET /status/v1/simple/\<SERVICE NAME\>
 
-Returns the plaintext status of the specified service, such as “rbac-service” or
+Returns the status of the specified service, such as “rbac-service” or
 “classifier-service”.
 
 #### Query Parameters

--- a/documentation/wire-formats.md
+++ b/documentation/wire-formats.md
@@ -1,5 +1,7 @@
 ## Status Wire Format - Version 1
 
+### JSON Endpoints
+
 Service status information is represented as JSON.  Unless otherwise noted, `null`
 is not allowed anywhere in the status data.
 
@@ -51,7 +53,7 @@ information from the specified service.
 `<any>` may be any valid JSON object (including `null`).  The data supplied here
  is specific to the individual service that is reporting status.
 
-## Errors
+#### Errors
 
 Error responses are formatted as a JSON _Object_:
 
@@ -66,7 +68,37 @@ of error that occurred.  For example, "service-status-version-not-found".
 `<error-message-string>` is a String with a descriptive message about the error
 that occurred.  For example: "No status function with version 2 found for service puppet-server".
 
-## Encoding
+#### Encoding
 
 The entire status payload is expected to be valid JSON, which mandates UTF-8
 encoding.
+
+### Simple (plaintext) endpoints
+
+The two simple endpoints (see the [query api documentation](./query-api.md))
+return strings correpsonding to the computed status of all known services.
+
+The possible responses are:
+
+* "running"
+* "error"
+* "unknown"
+* "starting"
+* "stopping"
+
+#### Errors
+
+If using the /simple/\<SERVICE NAME\> endpoint and the provided service is not
+found,
+
+* 404 "not found: \<SERVICE NAME\>"
+
+will be returned.
+
+It is important to note that when using the simple endpoints, a 503 response
+indicates a status other than _running_ and not a problem with the status
+service itself. However, a 5xx other than 503 would indicate such.
+
+#### Encoding
+
+The content type for these endpoints is `text/plain; charset=utf-8`.

--- a/documentation/wire-formats.md
+++ b/documentation/wire-formats.md
@@ -73,7 +73,7 @@ that occurred.  For example: "No status function with version 2 found for servic
 The entire status payload is expected to be valid JSON, which mandates UTF-8
 encoding.
 
-### Simple (plaintext) endpoints
+### Simple Endpoints
 
 The two simple endpoints (see the [query api documentation](./query-api.md))
 return strings correpsonding to the computed status of all known services.

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -328,7 +328,7 @@
 
       (testing "and a service is :unknown"
         (with-status-service app
-          [foo-service baz-service]
+          [foo-service baz-service starting-service stopping-service]
           (let [resp (http-client/get "http://localhost:8180/status/v1/simple")]
             (is (= 503 (:status resp)))
             (is (= "unknown" (slurp (:body resp))))))))


### PR DESCRIPTION
This PR:
- Updates the documentation index
- Adds information on the simple endpoints
- Links to the status proxy docs
