### PR TITLE
(SERVER-1310) Use standard error format

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
 
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/ring-middleware "0.3.1"]
+                 [puppetlabs/ring-middleware "1.0.0"]
                  [puppetlabs/comidi "0.3.1"]]
 
   :lein-release {:scm         :git

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -258,11 +258,11 @@
                                      service-status-version)
                                  service)))]
      (if (nil? status)
-       (throw+ {:type    :service-status-version-not-found
-                :message (str "No status function with version "
-                              service-status-version
-                              " found for service "
-                              service-name)})
+       (throw+ {:kind :service-status-version-not-found
+                :msg (str "No status function with version "
+                          service-status-version
+                          " found for service "
+                          service-name)})
        status)))
 
 (schema/defn ^:always-validate get-status-fn :- StatusFn
@@ -273,8 +273,8 @@
    service-status-version :- (schema/maybe schema/Int)]
   (let [service-info (-> services-info-atom deref (get service-name))]
      (if (nil? service-info)
-       (throw+ {:type    :service-info-not-found
-                :message (str "No service info found for service " service-name)})
+       (throw+ {:kind :service-info-not-found
+                :msg (str "No service info found for service " service-name)})
        (:status-fn (matching-service-info service-name service-info service-status-version)))))
 
 (schema/defn ^:always-validate call-status-fn-for-service :- ServiceStatus
@@ -328,8 +328,7 @@
   (if-let [level (keyword (params :level))]
     (if-not (schema/check ServiceStatusDetailLevel level)
       level
-      (throw+  {:type :request-data-invalid
-                :message (str "Invalid level: " level)}))
+      (ringutils/throw-data-invalid! (str "Invalid level: " level)))
     :info))
 
 (defn get-service-status-version
@@ -339,9 +338,9 @@
   (when-let [level (params :service_status_version)]
     (if-let [parsed-level (ks/parse-int level)]
       parsed-level
-      (throw+ {:type    :request-data-invalid
-               :message (str "Invalid service_status_version. Should be an "
-                          "integer but was " level)}))))
+      (ringutils/throw-data-invalid!
+       (str "Invalid service_status_version. Should be an integer but was "
+            level)))))
 
 (schema/defn ^:always-validate summarize-states :- State
   "Given a map of service statuses, return the 'most severe' state present as
@@ -413,9 +412,9 @@
               (assoc status :service_name service-name)))
           ;; else (no service with that name)
           (ringutils/json-response 404
-             {:type :service-not-found
-              :message (str "No status information found for service "
-                            service-name)})))))
+             {:kind :service-not-found
+              :msg  (str "No status information found for service "
+                         service-name)})))))
 
 (schema/defn ^:always-validate errors-by-type-middleware
   [t :- ringutils/ResponseType]

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -6,7 +6,8 @@
             [slingshot.slingshot :refer [throw+]]
             [puppetlabs.comidi :as comidi]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.ring-middleware.core :as ringutils]
+            [puppetlabs.ring-middleware.utils :as ringutils]
+            [puppetlabs.ring-middleware.core :as middleware]
             [trptcolin.versioneer.core :as versioneer]
             [clojure.java.jmx :as jmx])
   (:import (java.net URL)
@@ -420,9 +421,9 @@
   [t :- ringutils/ResponseType]
   (fn [handler]
     (-> handler
-        (ringutils/wrap-data-errors t)
-        (ringutils/wrap-schema-errors t)
-        (ringutils/wrap-uncaught-errors t))))
+        (middleware/wrap-data-errors t)
+        (middleware/wrap-schema-errors t)
+        (middleware/wrap-uncaught-errors t))))
 
 (defn build-handler [path status-fns]
   (comidi/routes->handler

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -54,10 +54,10 @@
 
       (let [status-fn (get-status-fn status-fns "foo" nil)]
         (is (= "foo v2" (status-fn)))
-        (is (thrown+? [:type :service-info-not-found :message "No service info found for service baz"]
+        (is (thrown+? [:kind :service-info-not-found :msg "No service info found for service baz"]
                       (get-status-fn status-fns "baz" nil)))
-        (is (thrown+? [:type :service-status-version-not-found
-                       :message "No status function with version 2 found for service bar"]
+        (is (thrown+? [:kind :service-status-version-not-found
+                       :msg "No status function with version 2 found for service bar"]
                       (get-status-fn status-fns "bar" 2)))))))
 
 (deftest error-handling-test


### PR DESCRIPTION
This moves us to the standard error format described in the [nogui](https://github.com/puppetlabs/puppet-nogui/blob/master/patterns/api_style_guide.md#errors) repo.

~~This is currently Do Not Merge [DNM] prep for after we have released ring-middleware 0.4.0.~~
We will also need to:
- [x] Update this to pull in the newest ring-middleware
- [x] Potentially update this for the reorg of helpers in ring-middleware into a utils namespace (not sure if that will land in 0.4.0).
