### PR TITLE
(maint) Resolve transitive dependency conflict with slf4j-api

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/tools.reader "1.0.0-alpha1"]
                  [org.clojure/tools.trace "0.7.9"]
+                 [org.slf4j/slf4j-api "1.7.13"]
                  ;; end list of version conflict resolution dependencies
 
                  [cheshire "5.6.1"]


### PR DESCRIPTION
This is blocking the release of 0.3.4 (do not know if this means we need to burn that tag).

Our release job is failing with:

```
Possibly confusing dependencies found:
[puppetlabs/trapperkeeper "1.4.0" :exclusions [org.clojure/clojure]] -> [ch.qos.logback/logback-classic "1.1.3"] -> [org.slf4j/slf4j-api "1.7.7"]
 overrides
[puppetlabs/ring-middleware "1.0.0" :exclusions [org.clojure/clojure]] -> [puppetlabs/http-client "0.5.0"] -> [org.slf4j/slf4j-api "1.7.13"]

Consider using these exclusions:
[puppetlabs/ring-middleware "1.0.0" :exclusions [org.clojure/clojure org.slf4j/slf4j-api]]

Aborting due to :pedantic? :abort
Build step 'Execute shell' marked build as failure
```

IIUC, we only see this dependency conflict when we go to release because because one of our testing dependencies (puppetlabs/http-client) solves the conflict for us during normal development.

Tested with `lein with-profile -dev deps` (sorry, didn't realize I should be doing this before).
