### PR TITLE
(PE-15985) Add alerts to status response

### DIFF
--- a/documentation/developers.md
+++ b/documentation/developers.md
@@ -19,7 +19,8 @@ Code sample:
   v1-status-callback :- status-core/StatusCallbackResponse
   [level :- status-core/ServiceStatusDetailLevel]
   {:state :running
-   :status (get-basic-status-for-my-service-at-level level)})
+   :status (get-basic-status-for-my-service-at-level level)
+   :alerts (get-alerts-at-level level)})
 
 (defservice foo-service
   [[:StatusService register-status]]
@@ -32,6 +33,14 @@ Code sample:
 ```
 
 ## Implementing Your Status Function
+
+Your status callback function should return a map that matches the
+status-core/StatusCallbackResponse schema. This means it should return a :state
+key, a :status key, and :alerts. :status and :alerts can change depending on
+the level specified to the function. Generally, :alerts should only be provided
+at the info level, unless you've decided you have some critical condition that
+is best notified about in prose. Keep in mind that most of our tools that will
+surface :alerts should query at info level.
 
 The `puppetlabs.trapperkeeper.services.status.status-core` namespace contains
 some utilities to aid in the implementation of your status functions.  In

--- a/documentation/query-api.md
+++ b/documentation/query-api.md
@@ -51,8 +51,14 @@ The response format will be a JSON _Object_, which will look something like this
         "service_status_version": <service-status-version>,
         "detail_level": <detail-level>,
         "state": <service-state>,
-        "status": <any>
-        },
+        "status": <any>,
+        "active_alerts": [
+          {
+           "severity": <severity>,
+           "message": <any string>
+          }
+        ]
+      },
      <service-name>: {
         ...
         },

--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -41,7 +41,8 @@
     (log/infof "Registering status callback function for %s service" service-name)
     (status-core/update-status-context (:status-fns (service-context this))
                                        service-name service-version status-version status-fn))
+
   (get-status [this service-name level status-version]
               (let [status-fn (status-core/get-status-fn (:status-fns (service-context this)) service-name status-version)
-          timeout (status-core/check-timeout level)]
+                    timeout (status-core/check-timeout level)]
                 (status-core/guarded-status-fn-call status-fn level timeout))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -115,6 +115,6 @@
         (is (= #{:committed :init :max :used} (ks/keyset (:heap-memory jvm-metrics))))
         (is (= #{:committed :init :max :used} (ks/keyset (:non-heap-memory jvm-metrics))))
         (is (every? #(< 0 %) (vals (:heap-memory jvm-metrics))))
-        (is (every? #(< 0 %) (vals (:non-heap-memory jvm-metrics))))
+        (is (every? #(or (< 0 %) (= -1 %)) (vals (:non-heap-memory jvm-metrics))))
         (is (< 0 (:up-time-ms jvm-metrics)))
         (is (< 0 (:start-time-ms jvm-metrics)))))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_proxy_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_proxy_service_test.clj
@@ -77,11 +77,13 @@
                            "service_status_version" 1
                            "state"                  "running"
                            "detail_level"           "info"
+                           "active_alerts"          []
                            "status"                 "bar status 1 :info"}
                     "foo" {"service_version"        "1.1.0"
                            "service_status_version" 2
                            "state"                  "running"
                            "detail_level"           "info"
+                           "active_alerts"          []
                            "status"                 "foo status 2 :info"}}
                    (dissoc body "status-service")))))
         (testing "proxying url with query param"
@@ -92,11 +94,13 @@
                            "service_status_version" 1
                            "state"                  "running"
                            "detail_level"           "debug"
+                           "active_alerts"          []
                            "status"                 "bar status 1 :debug"}
                     "foo" {"service_version"        "1.1.0"
                            "service_status_version" 2
                            "state"                  "running"
                            "detail_level"           "debug"
+                           "active_alerts"          []
                            "status"                 "foo status 2 :debug"}}
                    (dissoc body "status-service")))))
         (testing "proxying specific service"
@@ -108,6 +112,7 @@
                     "state"                  "running"
                     "detail_level"           "info"
                     "status"                 "foo status 2 :info"
+                    "active_alerts"          []
                     "service_name"           "foo"}
                   body))))))))
 


### PR DESCRIPTION
This PR enables developers to add a new key to their status callback
function's response, :alerts, where they can provide alert objects with
a severity and prose message. They will be returned by the HTTP endpoint
as a list under the key "active_alerts".

Earlier discussions indicated that alerts should only be shown at info
level, but typically services have determined what information to show
at which level, so I wrote this code to enable that, along with
documentation specifying that typically alerts should be shown at info
or below.
