### PR TITLE
(PE-16504) Timeout query parameter

### DIFF
--- a/documentation/query-api.md
+++ b/documentation/query-api.md
@@ -42,6 +42,14 @@ This will return status information for all registered services in an applicatio
 all registered services will be provided at the requested level of detail.  If
 not provided, the default level is `"info"`.
 
+* `timeout`: Optional. An integer specifying the timeout for the check in seconds.
+  If not provided, the default timeout will depend on the level.
+    * `"critical"`: 30 seconds.
+    * `"info"`: 30 seconds.
+    * `"debug"`: 60 seconds.
+  It is highly encouraged to use the timeout parameter to set a timeout that makes
+  sense for your environment.
+
 #### Response Format
 
 The response format will be a JSON _Object_, which will look something like this:
@@ -146,6 +154,14 @@ not provided, the default level is `"info"`.
 * `service_status_version`: Optional.  A JSON integer specifying the desired status
 format version for the requested service.  If not provided, defaults to the latest
 available status format version for the service.
+
+* `timeout`: Optional. An integer specifying the timeout for the check in seconds.
+  If not provided, the default timeout will depend on the level.
+    * `"critical"`: 30 seconds.
+    * `"info"`: 30 seconds.
+    * `"debug"`: 60 seconds.
+  It is highly encouraged to use the timeout parameter to set a timeout that makes
+  sense for your environment.
 
 #### Response Format
 

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -108,7 +108,7 @@
   a timeout when calling a status function."
   [level :- ServiceStatusDetailLevel]
   (case level
-    :critical 5
+    :critical 30
     :info 60
     :debug 60))
 

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -345,12 +345,12 @@
   "Given a params map from a request, get out the service status version and
    check whether it is valid. If not, throw an error."
   [params]
-  (when-let [level (params :service_status_version)]
-    (if-let [parsed-level (ks/parse-int level)]
-      parsed-level
+  (when-let [version (params :service_status_version)]
+    (if-let [numeric-version (ks/parse-int version)]
+      numeric-version
       (ringutils/throw-data-invalid!
        (str "Invalid service_status_version. Should be an integer but was "
-            level)))))
+            version)))))
 
 (schema/defn ^:always-validate summarize-states :- State
   "Given a map of service statuses, return the 'most severe' state present as

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -17,6 +17,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
 
+(def WholeSeconds schema/Int)
+(def WholeMilliseconds schema/Int)
+
 (def ServiceStatusDetailLevel
   (schema/enum :critical :info :debug))
 
@@ -74,8 +77,8 @@
 (def JvmMetricsV1
   {:heap-memory MemoryUsageV1
    :non-heap-memory MemoryUsageV1
-   :up-time-ms schema/Int
-   :start-time-ms schema/Int})
+   :up-time-ms WholeMilliseconds
+   :start-time-ms WholeMilliseconds})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
@@ -100,9 +103,9 @@
     (validation-error-explain schema-failure)
     schema-failure))
 
-(schema/defn check-timeout :- schema/Int
-  "Given a status level keyword, returns a number of seconds to use as a timeout
-  when calling a status function."
+(schema/defn check-timeout :- WholeSeconds
+  "Given a status level keyword, returns an integral number of seconds to use as
+  a timeout when calling a status function."
   [level :- ServiceStatusDetailLevel]
   (case level
     :critical 5
@@ -220,8 +223,8 @@
 
 (schema/defn ^:always-validate guarded-status-fn-call :- StatusCallbackResponse
   "Given a status check function, a status detail level, and a timeout in
-  seconds, this function calls the status function and handles three types of
-  errors:
+  (integral) seconds, this function calls the status function and handles three
+  types of errors:
 
   * Status check timed out
   * Status check threw an Exception
@@ -231,7 +234,7 @@
   string describing the error."
   [status-fn :- StatusFn
    level :- ServiceStatusDetailLevel
-   timeout :- schema/Int]
+   timeout :- WholeSeconds]
    (let [unknown-response (fn [status] {:state :unknown
                                         :status status})
          timeout-response (unknown-response (format "Status check timed out after %s seconds" timeout))]

--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -12,8 +12,11 @@
     the given level.  The return value of the callback function must satisfy
     the puppetlabs.trapperkeeper.services.status.status-core/StatusCallbackResponse
     schema.")
-  (get-status [this service-name level status-version]
-    "Call the status function for a registered service."))
+  (get-status
+    [this service-name level status-version]
+    [this service-name level status-version timeout]
+    "Call the status function for a registered service, optionally providing
+    a timeout to override the default timeout value for the level."))
 
 (defservice status-service
   StatusService
@@ -43,6 +46,8 @@
                                        service-name service-version status-version status-fn))
 
   (get-status [this service-name level status-version]
-              (let [status-fn (status-core/get-status-fn (:status-fns (service-context this)) service-name status-version)
-                    timeout (status-core/check-timeout level)]
-                (status-core/guarded-status-fn-call status-fn level timeout))))
+    (get-status this service-name level status-version (status-core/check-timeout level)))
+
+  (get-status [this service-name level status-version timeout]
+    (let [status-fn (status-core/get-status-fn (:status-fns (service-context this)) service-name status-version)]
+      (status-core/guarded-status-fn-call status-fn level timeout))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -77,15 +77,14 @@
         ; timeout
         (update-status-context status-fns "quux" "1.1.0" 1 (fn [_] (deref (promise)) {:state :running
                                                                                       :status "aw yis"}))
-        (with-redefs [puppetlabs.trapperkeeper.services.status.status-core/check-timeout (constantly 1)]
-          (with-test-logging
-            (let [result (call-status-fn-for-service "quux" (get @status-fns "quux") :debug)]
-              (is (logged? #"Status callback timed out" :error))
-              (is (logged? #"CancellationException"))
-              (testing "state is set properly"
-                (is (= :unknown (:state result))))
-              (testing "status is set to explain timeout"
-                (is (= "Status check timed out after 1 seconds" (:status result))))))))
+        (with-test-logging
+          (let [result (call-status-fn-for-service "quux" (get @status-fns "quux") :debug 0)]
+            (is (logged? #"Status callback timed out" :error))
+            (is (logged? #"CancellationException"))
+            (testing "state is set properly"
+              (is (= :unknown (:state result))))
+            (testing "status is set to explain timeout"
+              (is (= "Status check timed out after 0 seconds" (:status result)))))))
 
       (testing "and it is from the status reporting function"
         (update-status-context status-fns "bar" "1.1.0" 1 (fn [_] (throw (Exception. "don't"))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -66,7 +66,7 @@
     (let [status-fns (atom {})]
       (testing "and it is a bad callback result schema"
         (update-status-context status-fns "foo" "1.1.0" 1 (fn [_] {:totally :nonconforming}))
-        (let [result (call-status-fn-for-service "foo" (get @status-fns "foo") :debug)]
+        (let [result (call-status-fn-for-service "foo" (get @status-fns "foo") :debug 1)]
           (testing "status is set to explain schema error"
             (is (re-find #"missing-required-key" (pr-str result))))
           (testing "state is set properly"
@@ -90,7 +90,7 @@
       (testing "and it is from the status reporting function"
         (update-status-context status-fns "bar" "1.1.0" 1 (fn [_] (throw (Exception. "don't"))))
         (with-test-logging
-          (let [result (call-status-fn-for-service "bar" (get @status-fns "bar") :debug)]
+          (let [result (call-status-fn-for-service "bar" (get @status-fns "bar") :debug 1)]
             (is (logged? #"Status check threw an exception" :error))
             (testing "status contains exception"
               (is (re-find #"don't" (pr-str result))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -265,14 +265,13 @@
        broken-service
        baz-service]
       (testing "handles case when a status check times out"
-        (with-redefs [puppetlabs.trapperkeeper.services.status.status-core/check-timeout (constantly 1)]
-          (let [resp (http-client/get "http://localhost:8180/status/v1/services/slow?level=critical")
-                body (parse-response resp)]
-            (is (= 503 (:status resp)))
-            (is (= "unknown"
-                  (get body "state")))
-            (is (re-find #"timed out" (get body "status"))))))
-
+        (let [resp (http-client/get (str "http://localhost:8180/status/v1/services/slow"
+                                         "?level=critical&timeout=1"))
+              body (parse-response resp)]
+          (is (= 503 (:status resp)))
+          (is (= "unknown"
+                 (get body "state")))
+          (is (re-find #"timed out" (get body "status")))))
       (testing "handles case when a status check throws an exception"
         (let [resp (http-client/get "http://localhost:8180/status/v1/services/broken?level=critical")
               body (parse-response resp)]


### PR DESCRIPTION
Change all of the status endpoints to accept a "timeout" query
parameter, which should be the timeout value in integral seconds.
If the timeout value is not provided, the default value will be whatever
`status-core/check-timeout` returns for the check's level. Any timeout
value that's not a positive integer will cause a 400 to be returned to
the client.

Add a new arity to the `get-status` method of the StatusService
protocol. This arity takes a timeout argument that overrides the default
timeout value for the level.

Increase the default :critical level timeout to 30 seconds.

Interspersed with this are some unrelated improvements in the 
`(maint)` commits; see the messages for more details.
