### PR TITLE
(TK-409) Add gc counts and file descriptor usage to jvm-metrics

### DIFF
--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -110,10 +110,13 @@
       (is (= #{:jvm-metrics} (ks/keyset (get-in status [:status :experimental]))))
       (let [jvm-metrics (get-in status [:status :experimental :jvm-metrics])]
         (is (= #{:heap-memory :non-heap-memory
+                 :file-descriptors
                  :up-time-ms :start-time-ms} (ks/keyset jvm-metrics)))
         (is (= #{:committed :init :max :used} (ks/keyset (:heap-memory jvm-metrics))))
         (is (= #{:committed :init :max :used} (ks/keyset (:non-heap-memory jvm-metrics))))
         (is (every? #(< 0 %) (vals (:heap-memory jvm-metrics))))
         (is (every? #(or (< 0 %) (= -1 %)) (vals (:non-heap-memory jvm-metrics))))
+        (is (= #{:max :used} (ks/keyset (:file-descriptors jvm-metrics))))
+        (is (every? #(< 0 %) (vals (:file-descriptors jvm-metrics))))
         (is (< 0 (:up-time-ms jvm-metrics)))
         (is (< 0 (:start-time-ms jvm-metrics)))))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -110,7 +110,7 @@
       (is (= #{:jvm-metrics} (ks/keyset (get-in status [:status :experimental]))))
       (let [jvm-metrics (get-in status [:status :experimental :jvm-metrics])]
         (is (= #{:heap-memory :non-heap-memory
-                 :file-descriptors
+                 :file-descriptors :gc-stats
                  :up-time-ms :start-time-ms} (ks/keyset jvm-metrics)))
         (is (= #{:committed :init :max :used} (ks/keyset (:heap-memory jvm-metrics))))
         (is (= #{:committed :init :max :used} (ks/keyset (:non-heap-memory jvm-metrics))))
@@ -118,5 +118,10 @@
         (is (every? #(or (< 0 %) (= -1 %)) (vals (:non-heap-memory jvm-metrics))))
         (is (= #{:max :used} (ks/keyset (:file-descriptors jvm-metrics))))
         (is (every? #(< 0 %) (vals (:file-descriptors jvm-metrics))))
+        (is (every? #(= #{:count :total-time-ms} (ks/keyset %))
+                    (vals (:gc-stats jvm-metrics))))
+        (is (every? #(<= 0 %) ;; Possible that no major collections occurred.
+                    (mapcat #(vals %)
+                      (vals (:gc-stats jvm-metrics)))))
         (is (< 0 (:up-time-ms jvm-metrics)))
         (is (< 0 (:start-time-ms jvm-metrics)))))))


### PR DESCRIPTION
This PR adds two new entries to the `jvm-metrics` section of status output:
- `file-descriptors`: Which includes the maximum number of file descriptors allowed and the count of currently used descriptors.
- `gc-stats`: An array containing the count of GC events and time spent on garbage collection for each collector.
