### PR TITLE
[DON'T MERGE YET] (maint) Update ring-middleware and http-client dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-scheduler "0.0.1"]
-                 [puppetlabs/ring-middleware "1.0.0"]
+                 [puppetlabs/ring-middleware "1.0.1" :exclusions  [org.clojure/clojure org.slf4j/slf4j-api]]
                  [puppetlabs/comidi "0.3.1"]
                  [puppetlabs/i18n "0.4.3"]]
 
@@ -61,7 +61,7 @@
                                   [commons-io "2.5"]
                                   ;; End transitive dependency resolution
 
-                                  [puppetlabs/http-client "0.5.0"]
+                                  [puppetlabs/http-client "0.6.0" :exclusions  [org.clojure/clojure org.slf4j/slf4j-api]]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 "1.5.6"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]]}}


### PR DESCRIPTION
**This can't be merged until `ring-middleware 1.0.1` is released.**

Related PR: https://github.com/puppetlabs/ring-middleware/pull/40

If a trapperkeeper service brings in a previous version of trapperkeeper
status but is not using the clj-http-client project, starting up
tk-status results in a java.lang.ClassNotFound exception inside the
ring-middleware library. This commit updates the ring-middleware dep to
fix that problem so the class exists.

Stacktrace: https://gist.github.com/briancain/034f7ea9d2954f6d6f6f796095ec0016
