### PR TITLE
(TK-401) Log service name when error or timeout with service status callback

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -42,18 +42,26 @@ msgid "Unable to find version number for ''{0}/{1}''"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/status/status_core.clj
-msgid "Status check malformed: {0}"
+msgid "Status check timed out after {0} seconds"
+msgstr ""
+
+#: src/puppetlabs/trapperkeeper/services/status/status_core.clj
+msgid "Status callback for {0}"
+msgstr ""
+
+#: src/puppetlabs/trapperkeeper/services/status/status_core.clj
+msgid "Status check response for {0} malformed: {1}"
 msgstr ""
 
 #. if we get here it's almost certainly because the timeout was reached,
 #. so the macro already has a return value and we don't need to bother
 #. returning one
 #: src/puppetlabs/trapperkeeper/services/status/status_core.clj
-msgid "Status callback interrupted"
+msgid "Status callback for {0} interrupted"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/status/status_core.clj
-msgid "Status check threw an exception"
+msgid "Status check for {0} threw an exception"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/status/status_core.clj

--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -62,4 +62,4 @@
 
   (get-status [this service-name level status-version timeout]
     (let [status-fn (status-core/get-status-fn (:status-fns (service-context this)) service-name status-version)]
-      (status-core/guarded-status-fn-call status-fn level timeout))))
+      (status-core/guarded-status-fn-call service-name status-fn level timeout))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -79,7 +79,7 @@
                                                                                       :status "aw yis"}))
         (with-test-logging
           (let [result (call-status-fn-for-service "quux" (get @status-fns "quux") :debug 0)]
-            (is (logged? #"Status callback timed out" :error))
+            (is (logged? #"Status callback for quux timed out" :error))
             (is (logged? #"CancellationException"))
             (testing "state is set properly"
               (is (= :unknown (:state result))))
@@ -90,7 +90,7 @@
         (update-status-context status-fns "bar" "1.1.0" 1 (fn [_] (throw (Exception. "don't"))))
         (with-test-logging
           (let [result (call-status-fn-for-service "bar" (get @status-fns "bar") :debug 1)]
-            (is (logged? #"Status check threw an exception" :error))
+            (is (logged? #"Status check for bar threw an exception" :error))
             (testing "status contains exception"
               (is (re-find #"don't" (pr-str result))))
             (testing "state is set properly"

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -237,7 +237,7 @@
                 "service_status_version" 1
                 "state" "unknown"
                 "detail_level" "info"
-                "status" "Status check malformed: (not (map? \"baz\"))"
+                "status" "Status check response for baz malformed: (not (map? \"baz\"))"
                 "active_alerts" []
                 "service_name" "baz"}
               (parse-response resp)))))


### PR DESCRIPTION
This updates the signature of `guarded-status-fn-call` to accept the name of the service being checked. It then uses that name to identify the service when logging issues related to it (timeout, malformed response, other exception). Existing tests seemed to adequately test this change.