### PR TITLE
(TK-414) Add metrics for cpu/gc cpu usage

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/cpu_monitor.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/cpu_monitor.clj
@@ -1,0 +1,86 @@
+(ns puppetlabs.trapperkeeper.services.status.cpu-monitor
+  (:require [clojure.java.jmx :as jmx]
+            [puppetlabs.kitchensink.core :as ks]
+            [clojure.tools.logging :as log]
+            [schema.core :as schema])
+  (:import (java.lang.management ManagementFactory)
+           (java.util ArrayList)
+           (javax.management AttributeNotFoundException)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Schemas
+
+(def CpuUsageSnapshot
+  {:snapshot {:uptime schema/Int
+              :process-cpu-time schema/Int
+              :process-gc-time schema/Int}
+   :cpu-usage schema/Num
+   :gc-cpu-usage schema/Num})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Private
+
+(defn- cpu-multiplier*
+  []
+  (if (contains?
+       (vec (jmx/attribute-names "java.lang:type=OperatingSystem"))
+       :ProcessingCapacity)
+    (jmx/read "java.lang:type=OperatingSystem" :ProcessingCapacity)
+    1))
+
+(def cpu-multiplier (memoize cpu-multiplier*))
+
+(defn- gc-bean-names*
+  []
+  (jmx/mbean-names "java.lang:type=GarbageCollector,*"))
+
+(def gc-bean-names (memoize gc-bean-names*))
+
+(defn get-process-cpu-time
+  []
+  (let [bean-cpu-time (jmx/read "java.lang:type=OperatingSystem" :ProcessCpuTime)]
+    (* bean-cpu-time (cpu-multiplier))))
+
+(defn get-collection-time
+  []
+  (try
+    (apply + (map #(jmx/read % :CollectionTime) (gc-bean-names)))
+    (catch AttributeNotFoundException e
+      ;; Hopefully we will never hit this code path, but if we do, we should just
+      ;; log a warning and bail rather than letting the exception bubble up.
+      (log/warn "Found GC Bean that does not contain `:CollectionTime` attribute: "
+                (gc-bean-names))
+      0)))
+
+(defn calculate-usage
+  [process-time prev-process-time uptime-diff]
+  (if (or (= -1 prev-process-time) (<= uptime-diff 0))
+    0
+    (let [process-time-diff (- process-time prev-process-time)]
+      (min (* 100 (/ process-time-diff uptime-diff)) 100))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(schema/defn get-cpu-values :- CpuUsageSnapshot
+  [last-snapshot :- CpuUsageSnapshot]
+  (let [{prev-uptime :uptime
+         prev-process-cpu-time :process-cpu-time
+         prev-process-gc-time :process-gc-time} (:snapshot last-snapshot)]
+    (let [runtime-bean (ManagementFactory/getRuntimeMXBean)
+          ;; could cache / memoize num-cpus
+          num-cpus (ks/num-cpus)
+          uptime (* (.getUptime runtime-bean) 1000000)
+          process-cpu-time (/ (get-process-cpu-time) num-cpus)
+          process-gc-time (/ (* (get-collection-time) 1000000) num-cpus)
+          uptime-diff (if (= -1 prev-uptime) uptime (- uptime prev-uptime))
+          cpu-usage (calculate-usage process-cpu-time prev-process-cpu-time uptime-diff)
+          gc-usage (calculate-usage process-gc-time prev-process-gc-time uptime-diff)]
+
+      (let [result {:snapshot {:uptime uptime
+                               :process-cpu-time process-cpu-time
+                               :process-gc-time process-gc-time}
+                    :cpu-usage (float (max cpu-usage 0))
+                    :gc-cpu-usage (float (max gc-usage 0))}]
+        (log/trace "Latest cpu usage metrics: " (ks/pprint-to-string result))
+        result))))

--- a/src/puppetlabs/trapperkeeper/services/status/status_debug_logging.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_debug_logging.clj
@@ -2,13 +2,15 @@
   (:require [clojure.tools.logging :as log]
             [schema.utils :refer [validation-error-explain]]
             [cheshire.core :as json]
-            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]))
-(defn log-status
+            [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
+            [schema.core :as schema]
+            [puppetlabs.trapperkeeper.services.status.cpu-monitor :as cpu]))
+(schema/defn log-status
   "Log status information at the debug level as json
 
   Note: This function is in its own namespace so that logback can use the namespace
   as a way to route these log messages separately from other logging the application
   might be doing, and so it shouldn't be moved from this namespace"
-  []
-  (let [status (status-core/status-latest-version :debug)]
+  [last-cpu-snapshot :- (schema/atom cpu/CpuUsageSnapshot)]
+  (let [status (status-core/status-latest-version last-cpu-snapshot :debug)]
     (log/debug (json/generate-string status))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -511,3 +511,57 @@
        (Thread/sleep 100)
        (testing "no events have been logged"
          (is (empty? @event-maps))))))))
+
+(deftest cpu-metrics-test
+  (testing "cpu usage metrics are tracked when setting is enabled"
+    (with-status-service-with-config
+     app
+     []
+     (merge status-service-config {:status {:cpu-metrics-interval-seconds 0.02}})
+     (Thread/sleep 100)
+     (let [s (tka/get-service app :StatusService)
+           sc (service-context s)
+           first-cpu-snapshot @(:last-cpu-snapshot sc)
+           first-timers (:snapshot first-cpu-snapshot)]
+       (is (< 0 (:uptime first-timers)))
+       (is (< 0 (:process-cpu-time first-timers)))
+       (is (< 0 (:process-gc-time first-timers)))
+       (is (<= 0 (:cpu-usage first-cpu-snapshot)))
+       (is (<= 0 (:gc-cpu-usage first-cpu-snapshot)))
+
+       (Thread/sleep 100)
+       (let [second-cpu-snapshot @(:last-cpu-snapshot sc)
+             second-timers (:snapshot second-cpu-snapshot)]
+         (is (< (:uptime first-timers) (:uptime second-timers)))
+         (is (<= (:process-cpu-time first-timers) (:process-cpu-time second-timers)))
+         (is (<= (:process-gc-time first-timers) (:process-gc-time second-timers)))
+         (is (<= 0 (:cpu-usage first-cpu-snapshot)))
+         (is (<= 0 (:gc-cpu-usage first-cpu-snapshot)))
+
+
+         (testing "CPU metrics are accessible via http"
+           (let [resp (http-client/get "http://localhost:8180/status/v1/services/status-service?level=debug")]
+             (is (= 200 (:status resp)))
+             (let [body (parse-response resp true)
+                   jvm-metrics (get-in body [:status :experimental :jvm-metrics])]
+               (is (<= 0 (:cpu-usage jvm-metrics)))
+               (is (<= 0 (:gc-cpu-usage jvm-metrics))))))))))
+  (testing "cpu usage metrics are not updated when setting is disabled"
+    (with-status-service-with-config
+     app
+     []
+     (merge status-service-config {:status {:cpu-metrics-interval-seconds 0}})
+     ;; TODO: this test doesn't really cover anything without a sleep that is
+     ;; longer than the default interval, and I don't really want to sleep that
+     ;; long in the test, so it's not really useful.  Should try to think of
+     ;; a better way to test the "disabled" case.
+     (Thread/sleep 100)
+     (let [s (tka/get-service app :StatusService)
+           sc (service-context s)
+           last-cpu-snapshot @(:last-cpu-snapshot sc)
+           timers (:snapshot last-cpu-snapshot)]
+       (is (= -1 (:uptime timers)))
+       (is (= -1 (:process-cpu-time timers)))
+       (is (= -1 (:process-gc-time timers)))
+       (is (= -1 (:cpu-usage last-cpu-snapshot)))
+       (is (= -1 (:gc-cpu-usage last-cpu-snapshot)))))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -538,7 +538,6 @@
          (is (<= 0 (:cpu-usage first-cpu-snapshot)))
          (is (<= 0 (:gc-cpu-usage first-cpu-snapshot)))
 
-
          (testing "CPU metrics are accessible via http"
            (let [resp (http-client/get "http://localhost:8180/status/v1/services/status-service?level=debug")]
              (is (= 200 (:status resp)))


### PR DESCRIPTION
This commit introduces CPU usage metrics into the `:jvm-metrics` section
of the status callback.  It includes two fields, `:cpu-usage` and `:gc-cpu-usage`,
whose values are percentages of CPU capacity on the machine.

The code to compute these values was ported from the source code for JVisualVM.
    
By default, we update the values of these metrics every 5 seconds.  The interval
can be modified by providing a value for the new setting
`[:status :cpu-metrics-interval-seconds]` in the trapperkeeper config.
