### PR TITLE
(PE-13539) Log service version numbers at startup

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -105,5 +105,5 @@ msgid "Registering status service HTTP API at /status"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/status/status_service.clj
-msgid "Registering status callback function for {0} service"
+msgid "Registering status callback function for service ''{0}'', version {1}"
 msgstr ""

--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -53,7 +53,7 @@
     context)
 
   (register-status [this service-name service-version status-version status-fn]
-    (log/infof (i18n/trs "Registering status callback function for {0} service" service-name))
+    (log/infof (i18n/trs "Registering status callback function for service ''{0}'', version {1}" service-name service-version))
     (status-core/update-status-context (:status-fns (service-context this))
                                        service-name service-version status-version status-fn))
 


### PR DESCRIPTION
This commit will cause the status service, during startup, to log
the version numbers for each service that registers a callback.