### PR TITLE
(MAINT) prep for 0.7.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 jdk:
 - oraclejdk7
 - openjdk7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.7.0
+
+This is a feature release.
+
+* [PE-13539](https://tickets.puppetlabs.com/browse/PE-13539) At startup, log
+  version numbers for all services that register themselves with the status
+  service.
+* [TK-414](https://tickets.puppetlabs.com/browse/TK-414) Add metrics about
+  CPU usage and GC CPU usage to the default JVM metrics available from the
+  HTTP endpoint at `debug` level.
+* [TK-401](https://tickets.puppetlabs.com/browse/TK-401) Include service name
+  in log message when a service's callback fails due to error or timeout
+
 ## 0.6.0
 
 This is a feature release.

--- a/project.clj
+++ b/project.clj
@@ -19,8 +19,15 @@
                  [slingshot]
                  [prismatic/schema]
                  [trptcolin/versioneer]
-                 [ring/ring-defaults]
+                 ;; ring-defaults brings in a bad, old version of the servlet-api, which
+                 ;; now has a new artifact name (javax.servlet/javax.servlet-api).  If we
+                 ;; don't exclude the old one here, they'll both be brought in, and consumers
+                 ;; will be subject to the whims of which one shows up on the classpath first.
+                 ;; thus, we need to use exclusions here, even though we'd normally resolve
+                 ;; this type of thing by just specifying a fixed dependency version.
+                 [ring/ring-defaults :exclusions [javax.servlet/servlet-api]]
                  [org.clojure/java.jmx]
+                 [org.clojure/tools.logging]
 
                  [puppetlabs/kitchensink]
                  [puppetlabs/trapperkeeper]

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "1.3.0")
 
 
-(defproject puppetlabs/trapperkeeper-status "0.6.1-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-status "0.7.0-SNAPSHOT"
   :description "A trapperkeeper service for getting the status of other trapperkeeper services."
   :url "https://github.com/puppetlabs/trapperkeeper-status"
   :license {:name "Apache License, Version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,70 +1,43 @@
-(def tk-version "1.4.0")
-(def ks-version "1.3.0")
-
-
 (defproject puppetlabs/trapperkeeper-status "0.7.0-SNAPSHOT"
   :description "A trapperkeeper service for getting the status of other trapperkeeper services."
   :url "https://github.com/puppetlabs/trapperkeeper-status"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
+  :min-lein-version "2.7.1"
+
+  :parent-project {:coords [puppetlabs/clj-parent "0.2.5"]
+                   :inherit [:managed-dependencies]}
+
   :pedantic? :abort
 
   :exclusions [org.clojure/clojure]
 
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure]
 
-                 ;; Dependencies which resolve version conflicts via
-                 ;; :pedantic? :abort in transitive dependencies
-                 [clj-time "0.11.0"]
-                 [ring "1.4.0"]
-                 [commons-codec "1.10"]
-                 [org.clojure/tools.macro "0.1.5"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [org.clojure/tools.reader "1.0.0-alpha1"]
-                 [org.clojure/tools.trace "0.7.9"]
-                 [org.slf4j/slf4j-api "1.7.13"]
-                 ;; end list of version conflict resolution dependencies
+                 [cheshire]
+                 [slingshot]
+                 [prismatic/schema]
+                 [trptcolin/versioneer]
+                 [ring/ring-defaults]
+                 [org.clojure/java.jmx]
 
-                 [cheshire "5.6.1"]
-                 [prismatic/schema "1.1.1"]
-                 ;; ring-defaults brings in a bad, old version of the servlet-api, which
-                 ;; now has a new artifact name (javax.servlet/javax.servlet-api).  If we
-                 ;; don't exclude the old one here, they'll both be brought in, and consumers
-                 ;; will be subject to the whims of which one shows up on the classpath first.
-                 ;; thus, we need to use exclusions here, even though we'd normally resolve
-                 ;; this type of thing by just specifying a fixed dependency version.
-                 [ring/ring-defaults "0.2.0" :exclusions [javax.servlet/servlet-api]]
-
-                 [slingshot "0.12.2"]
-                 [trptcolin/versioneer "0.2.0"]
-                 [org.clojure/java.jmx "0.3.1"]
-
-                 [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/trapperkeeper-scheduler "0.0.1"]
-                 [puppetlabs/ring-middleware "1.0.0"]
-                 [puppetlabs/comidi "0.3.1"]
-                 [puppetlabs/i18n "0.4.3"]]
-
-  :lein-release {:scm         :git
-                 :deploy-via  :lein-deploy}
+                 [puppetlabs/kitchensink]
+                 [puppetlabs/trapperkeeper]
+                 [puppetlabs/trapperkeeper-scheduler]
+                 [puppetlabs/ring-middleware]
+                 [puppetlabs/comidi]
+                 [puppetlabs/i18n]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]]
 
-  :profiles {:dev {:dependencies [
-                                  ;; Begin transitive dependency resolution
-                                  [clj-time "0.11.0"]
-                                  [commons-io "2.5"]
-                                  ;; End transitive dependency resolution
+  :profiles {:dev {:dependencies [[puppetlabs/http-client]
+                                  [puppetlabs/trapperkeeper nil :classifier "test"]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9]
+                                  [puppetlabs/kitchensink nil :classifier "test"]]}}
 
-                                  [puppetlabs/http-client "0.5.0"]
-                                  [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
-                                  [puppetlabs/trapperkeeper-webserver-jetty9 "1.5.6"]
-                                  [puppetlabs/kitchensink ~ks-version :classifier "test"]]}}
-
-  :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
+  :plugins [[lein-parent "0.3.1"]
             [puppetlabs/i18n "0.4.3"]])

--- a/project.clj
+++ b/project.clj
@@ -35,9 +35,9 @@
                                      :sign-releases false}]]
 
   :profiles {:dev {:dependencies [[puppetlabs/http-client]
-                                  [puppetlabs/trapperkeeper nil :classifier "test"]
+                                  [puppetlabs/trapperkeeper :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9]
-                                  [puppetlabs/kitchensink nil :classifier "test"]]}}
+                                  [puppetlabs/kitchensink :classifier "test"]]}}
 
   :plugins [[lein-parent "0.3.1"]
             [puppetlabs/i18n "0.4.3"]])


### PR DESCRIPTION
This PR updates the CHANGELOG in preparation for the 0.7.0 release.

It also includes a commit that introduces `clj-parent` and gets rid of some unnecessary transitive dependency resolution info.