### PR TITLE
(MAINT) Avoid a schema error during an early shutdown

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -54,7 +54,8 @@
     context)
 
   (stop [this context]
-    (status-core/reset-status-context! (:status-fns context))
+    (when-let [status-fns (:status-fns context)]
+      (status-core/reset-status-context! status-fns))
     context)
 
   (register-status [this service-name service-version status-version status-fn]


### PR DESCRIPTION
Previously, if a startup error were encountered before the status
service's init function was called, a call to the stop function could
throw/log a schema error when trying to manipulate state that had not
been set on the context during the init call.

With this commit, the status service just avoids the code which would
reset context state that doesn't exist, avoiding the appearance of
the schema error.