### PR TITLE
(TK-430) Bump clj-parent to 0.3.3 and i18n to 0.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.2.5"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.3.3"]
                    :inherit [:managed-dependencies]}
 
   :pedantic? :abort
@@ -47,4 +47,4 @@
                                   [puppetlabs/kitchensink :classifier "test"]]}}
 
   :plugins [[lein-parent "0.3.1"]
-            [puppetlabs/i18n "0.4.3"]])
+            [puppetlabs/i18n "0.6.0"]])


### PR DESCRIPTION
This commit bumps the clj-parent dependency to 0.3.3 and i18n plugin
dependency to 0.6.0.