### PR TITLE
(maint) Update clj-parent to 1.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: clojure
 lein: 2.7.1
 jdk:
-- oraclejdk7
-- openjdk7
+  - oraclejdk8
+  - openjdk8
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.6.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.4.3"]
                    :inherit [:managed-dependencies]}
 
   :pedantic? :abort
@@ -19,13 +19,7 @@
                  [slingshot]
                  [prismatic/schema]
                  [trptcolin/versioneer]
-                 ;; ring-defaults brings in a bad, old version of the servlet-api, which
-                 ;; now has a new artifact name (javax.servlet/javax.servlet-api).  If we
-                 ;; don't exclude the old one here, they'll both be brought in, and consumers
-                 ;; will be subject to the whims of which one shows up on the classpath first.
-                 ;; thus, we need to use exclusions here, even though we'd normally resolve
-                 ;; this type of thing by just specifying a fixed dependency version.
-                 [ring/ring-defaults :exclusions [javax.servlet/servlet-api]]
+                 [ring/ring-defaults]
                  [org.clojure/java.jmx]
                  [org.clojure/tools.logging]
 


### PR DESCRIPTION
This patch updates the clj-parent dependency to 1.4.1 and drops a now-obsolete
exclusion of javax.servlet/servlet-api from the ring/ring-defaults
dependency.