### PR TITLE
(TK-455) Backport service name reporting on timeout to 0.6 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 jdk:
 - oraclejdk7
 - openjdk7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.6.1
+
+This is a minor release. It includes
+
+* [TK-401](https://tickets.puppetlabs.com/browse/TK-401) Include service name
+  in log message when a service's callback fails due to error or timeout
+
+from 0.7.0 to improve debugging for those users pinned to 0.6.x.
+
+
 ## 0.6.0
 
 This is a feature release.

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-lein2 test
+lein test

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -42,18 +42,26 @@ msgid "Unable to find version number for ''{0}/{1}''"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/status/status_core.clj
-msgid "Status check malformed: {0}"
+msgid "Status check timed out after {0} seconds"
+msgstr ""
+
+#: src/puppetlabs/trapperkeeper/services/status/status_core.clj
+msgid "Status callback for {0}"
+msgstr ""
+
+#: src/puppetlabs/trapperkeeper/services/status/status_core.clj
+msgid "Status check response for {0} malformed: {1}"
 msgstr ""
 
 #. if we get here it's almost certainly because the timeout was reached,
 #. so the macro already has a return value and we don't need to bother
 #. returning one
 #: src/puppetlabs/trapperkeeper/services/status/status_core.clj
-msgid "Status callback interrupted"
+msgid "Status callback for {0} interrupted"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/status/status_core.clj
-msgid "Status check threw an exception"
+msgid "Status check for {0} threw an exception"
 msgstr ""
 
 #: src/puppetlabs/trapperkeeper/services/status/status_core.clj

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def ks-version "1.3.0")
 
 
-(defproject puppetlabs/trapperkeeper-status "0.6.0"
+(defproject puppetlabs/trapperkeeper-status "0.6.1-SNAPSHOT"
   :description "A trapperkeeper service for getting the status of other trapperkeeper services."
   :url "https://github.com/puppetlabs/trapperkeeper-status"
   :license {:name "Apache License, Version 2.0"

--- a/src/puppetlabs/trapperkeeper/services/status/status_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_service.clj
@@ -62,4 +62,4 @@
 
   (get-status [this service-name level status-version timeout]
     (let [status-fn (status-core/get-status-fn (:status-fns (service-context this)) service-name status-version)]
-      (status-core/guarded-status-fn-call status-fn level timeout))))
+      (status-core/guarded-status-fn-call service-name status-fn level timeout))))

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -79,7 +79,7 @@
                                                                                       :status "aw yis"}))
         (with-test-logging
           (let [result (call-status-fn-for-service "quux" (get @status-fns "quux") :debug 0)]
-            (is (logged? #"Status callback timed out" :error))
+            (is (logged? #"Status callback for quux timed out" :error))
             (is (logged? #"CancellationException"))
             (testing "state is set properly"
               (is (= :unknown (:state result))))
@@ -90,7 +90,7 @@
         (update-status-context status-fns "bar" "1.1.0" 1 (fn [_] (throw (Exception. "don't"))))
         (with-test-logging
           (let [result (call-status-fn-for-service "bar" (get @status-fns "bar") :debug 1)]
-            (is (logged? #"Status check threw an exception" :error))
+            (is (logged? #"Status check for bar threw an exception" :error))
             (testing "status contains exception"
               (is (re-find #"don't" (pr-str result))))
             (testing "state is set properly"

--- a/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_service_test.clj
@@ -237,7 +237,7 @@
                 "service_status_version" 1
                 "state" "unknown"
                 "detail_level" "info"
-                "status" "Status check malformed: (not (map? \"baz\"))"
+                "status" "Status check response for baz malformed: (not (map? \"baz\"))"
                 "active_alerts" []
                 "service_name" "baz"}
               (parse-response resp)))))


### PR DESCRIPTION
This brings back
  - (TK-401) Log service name when error or timeout with service status callback

I believe our CI pipelines have been updated to auto generate the pot files that will need to be changed with this. However, I will double check that and may possibly need to bring back ddf96a7
 as well.