### PR TITLE
(TK-460) Add thread counts to status metrics

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -82,6 +82,10 @@
   {:max schema/Int
    :used schema/Int})
 
+(def ThreadingV1
+  {:thread-count schema/Int
+   :peak-thread-count schema/Int})
+
 (def GcStatsV1
   {schema/Str {:count schema/Int
                :total-time-ms schema/Int
@@ -91,6 +95,7 @@
   {:heap-memory MemoryUsageV1
    :non-heap-memory MemoryUsageV1
    :file-descriptors FileDescriptorUsageV1
+   :threading ThreadingV1
    :gc-stats GcStatsV1
    :up-time-ms WholeMilliseconds
    :start-time-ms WholeMilliseconds
@@ -188,6 +193,11 @@
      :file-descriptors (setutils/rename-keys
                         (jmx/read "java.lang:type=OperatingSystem" [:OpenFileDescriptorCount :MaxFileDescriptorCount])
                         {:OpenFileDescriptorCount :used :MaxFileDescriptorCount :max})
+     :threading (setutils/rename-keys
+                  (jmx/read "java.lang:type=Threading"
+                            [:ThreadCount :PeakThreadCount])
+                  {:ThreadCount :thread-count
+                   :PeakThreadCount :peak-thread-count})
      :gc-stats (into {} (for [gc gc-beans]
                           (let [gc-name (.getKeyProperty gc "name")
                                 gc-info (read-gc-info gc)]

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -115,7 +115,7 @@
         (is (= #{:jvm-metrics} (ks/keyset (get-in status [:status :experimental]))))
         (let [jvm-metrics (get-in status [:status :experimental :jvm-metrics])]
           (is (= #{:heap-memory :non-heap-memory
-                   :file-descriptors :gc-stats
+                   :file-descriptors :threading :gc-stats
                    :up-time-ms :start-time-ms
                    :cpu-usage :gc-cpu-usage} (ks/keyset jvm-metrics)))
           (is (= #{:committed :init :max :used} (ks/keyset (:heap-memory jvm-metrics))))


### PR DESCRIPTION
This patch adds the ThreadCount and PeakThreadCount metrics from the
java.lang:type=Threading MBean to the set of metrics reported by the
status service. These values can be used to detect spikes in the number
of threads spawned by a TrapperKeeper service.