### PR TITLE
(PE-24670) Make status service respect tk-auth configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
+## 1.1.0
+
+This is a feature release.
+
+* [PE-24670](https://tickets.puppetlabs.com/browse/PE-24670) Add ability for
+  applications using trapperkeeper to require authentication for the status
+  endpoint.
+
 ## 1.0.0
+
 This is a feature release
 
 * [TK-460](https://tickets.puppetlabs.com/browse/TK-460)

--- a/documentation/developers.md
+++ b/documentation/developers.md
@@ -92,6 +92,26 @@ web-router-service: {
 For information on proxying plaintext `/status` requests to an otherwise HTTPS
 protected server, see the [Status Proxy documentation](./status-proxy-service.md).
 
+Applications using trapperkeeper can require authentication for the status endpoint.
+For this to happen, tk-auth must be included in the application's bootstrap config
+file.  Then, to enable authentication, the application's tk-auth
+configuration file needs to be updated to include this authorization rule:
+
+```
+{
+   # Disallow unauthenticated access to the status service endpoint
+    match-request: {
+        path: "/status/v1/services"
+        type: path
+        method: get
+    }
+    allow-unauthenticated: false
+    allow: "*"
+    sort-order: 500
+    name: "puppetlabs status service"
+}
+```
+
 ## Details
 
 See [Query API](./query-api.md) and [Wire Format](./wire-formats.md) for details

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/trapperkeeper-status "1.0.1-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-status "1.1.0-SNAPSHOT"
   :description "A trapperkeeper service for getting the status of other trapperkeeper services."
   :url "https://github.com/puppetlabs/trapperkeeper-status"
   :license {:name "Apache License, Version 2.0"
@@ -28,7 +28,8 @@
                  [puppetlabs/trapperkeeper-scheduler]
                  [puppetlabs/ring-middleware]
                  [puppetlabs/comidi]
-                 [puppetlabs/i18n]]
+                 [puppetlabs/i18n]
+                 [puppetlabs/trapperkeeper-authorization]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username


### PR DESCRIPTION
Wrap status service routes so that access to the
status/v1/services endpoint can be configured to require
cert-authentication. If no authorization service is running,
the status service will default to allow unauthenticated
requests.