### PR TITLE
(TK-490, TK-491) Add memory pool and buffer pool metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
 language: clojure
-lein: 2.7.1
+lein: 2.9.1
+dist: bionic
 jdk:
   - openjdk8
 script: ./ext/travisci/test.sh
 notifications:
   email: false
-  hipchat:
-    rooms:
-      secure: CfGS3yYsocLruSP0lRr9HFwzdZ1HFw4rFEVdJkP/i0i8aIPY3XB3vTQNxw/lIBVRDwWHaUfA+xnyK3itCxt0M0UtPDp1BkU6abLr8Apjet/nJJ2icBvQfnpx1hb6xBpoE69vpRiIVewoU69UPFjXdZd2D1BWX58tNbdV9CA8Ezw=
-    template:
-    - ! '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}'
-    - ! 'Change view: %{compare_url}'
-    - ! 'Build details: %{build_url}'

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.5.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.38"]
                    :inherit [:managed-dependencies]}
 
   :pedantic? :abort
@@ -41,5 +41,5 @@
                                   [puppetlabs/trapperkeeper-webserver-jetty9]
                                   [puppetlabs/kitchensink :classifier "test"]]}}
 
-  :plugins [[lein-parent "0.3.1"]
-            [puppetlabs/i18n "0.8.0"]])
+  :plugins [[lein-parent "0.3.8"]
+            [puppetlabs/i18n "0.8.0" :hooks false]])

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -115,7 +115,7 @@
         (is (= #{:jvm-metrics} (ks/keyset (get-in status [:status :experimental]))))
         (let [jvm-metrics (get-in status [:status :experimental :jvm-metrics])]
           (is (= #{:heap-memory :non-heap-memory :memory-pools
-                   :file-descriptors :threading :gc-stats
+                   :file-descriptors :nio-buffer-pools :threading :gc-stats
                    :up-time-ms :start-time-ms
                    :cpu-usage :gc-cpu-usage} (ks/keyset jvm-metrics)))
           (is (= #{:committed :init :max :used} (ks/keyset (:heap-memory jvm-metrics))))
@@ -124,6 +124,8 @@
           (is (every? #(< 0 %) (vals (:heap-memory jvm-metrics))))
           (is (every? #(or (< 0 %) (= -1 %)) (vals (:non-heap-memory jvm-metrics))))
           (is (= #{:max :used} (ks/keyset (:file-descriptors jvm-metrics))))
+          (is (= #{:count :memory-used :total-capacity}
+                 (ks/keyset (-> jvm-metrics :nio-buffer-pools first val))))
           (is (every? #(< 0 %) (vals (:file-descriptors jvm-metrics))))
           (is (contains? jvm-metrics :gc-stats))
           (is (< 0 (:up-time-ms jvm-metrics)))

--- a/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_core_test.clj
@@ -114,12 +114,13 @@
         (is (= #{:experimental} (ks/keyset (:status status))))
         (is (= #{:jvm-metrics} (ks/keyset (get-in status [:status :experimental]))))
         (let [jvm-metrics (get-in status [:status :experimental :jvm-metrics])]
-          (is (= #{:heap-memory :non-heap-memory
+          (is (= #{:heap-memory :non-heap-memory :memory-pools
                    :file-descriptors :threading :gc-stats
                    :up-time-ms :start-time-ms
                    :cpu-usage :gc-cpu-usage} (ks/keyset jvm-metrics)))
           (is (= #{:committed :init :max :used} (ks/keyset (:heap-memory jvm-metrics))))
           (is (= #{:committed :init :max :used} (ks/keyset (:non-heap-memory jvm-metrics))))
+          (is (= #{:type :usage} (ks/keyset (-> jvm-metrics :memory-pools first val))))
           (is (every? #(< 0 %) (vals (:heap-memory jvm-metrics))))
           (is (every? #(or (< 0 %) (= -1 %)) (vals (:non-heap-memory jvm-metrics))))
           (is (= #{:max :used} (ks/keyset (:file-descriptors jvm-metrics))))


### PR DESCRIPTION
This patchset adds metrics from the JMX MemoryPoolMXBean instances to
the set of data returned by the `status-service` at DEBUG level.
These metrics break down memory usage in the heap and non-heap
regions into different categories of usage. Off-heap memory is
not completely accounted, but important uses like the CodeCache
for the Java JIT compiler are returned.

The Travis CI configuration is also cleaned up and updated.

Metrics from the JMX MemoryPoolMXBean instances are also collected.