### PR TITLE
(maint) Update clj-parent to 5.1.1; fips config; dynapath; fix core reflection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: clojure
 lein: 2.9.1
-dist: bionic
+dist: focal
 jdk:
-  - openjdk8
+  - openjdk11
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
   :dependencies [[org.clojure/clojure]
 
                  [cheshire]
+                 [org.tcrawley/dynapath "1.0.0"]
                  [slingshot]
                  [prismatic/schema]
                  [trptcolin/versioneer]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.38"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.1.1"]
                    :inherit [:managed-dependencies]}
 
   :pedantic? :abort

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,8 @@
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]]
 
-  :profiles {:dev {:dependencies [[puppetlabs/http-client]
+  :profiles {:dev {:dependencies [[org.bouncycastle/bcpkix-jdk15on]
+                                  [puppetlabs/http-client]
                                   [puppetlabs/trapperkeeper :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9]
                                   [puppetlabs/kitchensink :classifier "test"]]}}

--- a/src/puppetlabs/trapperkeeper/services/status/status_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/status/status_core.clj
@@ -19,6 +19,9 @@
            (javax.management ObjectName)
            (clojure.lang IFn)))
 
+
+(set! *warn-on-reflection* true)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
 
@@ -167,7 +170,7 @@
                         (i18n/tru "Cannot register multiple callbacks for a single service with different service versions.")
                         (i18n/tru "Service function already exists for service {0} with status version {1}" svc-name status-version))]
     (when (or differing-svc-version? differing-status-version?)
-      (throw (IllegalStateException. error-message)))))
+      (throw (IllegalStateException. ^String error-message)))))
 
 (defn validate-protocol!
   "Throws if the protocol is not http or https"
@@ -209,7 +212,7 @@
   []
   (let [memory-pool-beans (jmx/mbean-names "java.lang:name=*,type=MemoryPool")]
     (into {} (for [pool memory-pool-beans]
-               (let [pool-name (.getKeyProperty pool "name")
+               (let [pool-name (.getKeyProperty ^ObjectName pool "name")
                      pool-info (read-memory-pool-info pool)]
                  {pool-name pool-info})))))
 
@@ -228,7 +231,7 @@
   []
   (let [buffer-pool-beans (jmx/mbean-names "java.nio:name=*,type=BufferPool")]
     (into {} (for [pool buffer-pool-beans]
-               (let [pool-name (.getKeyProperty pool "name")
+               (let [pool-name (.getKeyProperty ^ObjectName pool "name")
                      pool-info (read-buffer-pool-info pool)]
                  {pool-name pool-info})))))
 
@@ -249,7 +252,7 @@
                   {:ThreadCount :thread-count
                    :PeakThreadCount :peak-thread-count})
      :gc-stats (into {} (for [gc gc-beans]
-                          (let [gc-name (.getKeyProperty gc "name")
+                          (let [gc-name (.getKeyProperty ^ObjectName gc "name")
                                 gc-info (read-gc-info gc)]
                             {gc-name gc-info})))
      :cpu-usage (:cpu-usage cpu-snapshot)
@@ -305,10 +308,10 @@
   [group-id artifact-id]
   (let [version (versioneer/get-version group-id artifact-id)]
     (when (empty? version)
-      (throw (IllegalStateException.
-               (i18n/tru "Unable to find version number for ''{0}/{1}''"
-                 group-id
-                 artifact-id))))
+      (let [^String msg (i18n/tru "Unable to find version number for ''{0}/{1}''"
+                                  group-id
+                                  artifact-id)]
+        (throw (IllegalStateException. msg))))
     version))
 
 (def status-service-version

--- a/test/puppetlabs/trapperkeeper/services/status/status_proxy_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/status/status_proxy_service_test.clj
@@ -178,7 +178,7 @@
                        dissoc :proxy-target-url)]
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
-            #"does not match schema.*:proxy-target-url"
+            #"(?s)does not match schema.*:proxy-target-url"
             (with-test-logging
               (with-app-with-config
                 proxy-app
@@ -193,7 +193,7 @@
                        3.1415)]
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
-            #"does not match schema.*:ssl-cert"
+            #"(?s)does not match schema.*:ssl-cert"
             (with-test-logging
               (with-app-with-config
                 proxy-app


### PR DESCRIPTION
I started this because I'd noticed what looked like notable reflection cost in some pdb flame graphs while working on escalations, and I thought it'd be easy to fix.  Several yaks later, this pr.

It also turned out that I'd misread the graph, and that further down, the real culprit was the i18n reflection problem that we've fixed in newer versions, so we don't have to keep the status-core reflection fixes, but I thought they might be worthwhile since they're fairly straightforward and not too noisy.

See the individual commit messages for specific details.